### PR TITLE
Added tool waitlist feature along with minor tool type improvements

### DIFF
--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -80,11 +80,12 @@ class CheckoutsController < ApplicationController
             waitlist.active = false
             waitlist.save
             removed_from_waitlist =
-                "#{waitlist.participant.name} (#{waitlist.organization.short_name}) was removed from the waitlist for #{waitlist.tool_type.name.pluralize}."
+                "  #{waitlist.participant.name} was removed from the waitlist for #{waitlist.tool_type.name.pluralize}."
+            break
           end
         end
 
-        format.html { redirect_to tool_path(@checkout.tool), notice: "Checkout was successfully created.  #{removed_from_waitlist}" }
+        format.html { redirect_to tool_path(@checkout.tool), notice: "Checkout was successfully created.#{removed_from_waitlist}" }
         format.json { render json: @checkout.tool, status: :created, location: @checkout.tool }
       else
         format.html { render action: "new" }

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -73,7 +73,18 @@ class CheckoutsController < ApplicationController
 
     respond_to do |format|
       if @checkout.save
-        format.html { redirect_to tool_path(@checkout.tool), notice: 'Checkout was successfully created.' }
+        removed_from_waitlist = ""
+        @checkout.tool.tool_type.tool_waitlists.each do |waitlist|
+          if waitlist.organization == @checkout.organization
+            # Automatically remove the person from the waitlist
+            waitlist.active = false
+            waitlist.save
+            removed_from_waitlist =
+                "#{waitlist.participant.name} (#{waitlist.organization.short_name}) was removed from the waitlist for #{waitlist.tool_type.name.pluralize}."
+          end
+        end
+
+        format.html { redirect_to tool_path(@checkout.tool), notice: "Checkout was successfully created.  #{removed_from_waitlist}" }
         format.json { render json: @checkout.tool, status: :created, location: @checkout.tool }
       else
         format.html { render action: "new" }

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -16,11 +16,17 @@ class HomeController < ApplicationController
 
     @query = params[:query]
 
+    @tool_lookup = Tool.find_by_barcode(@query)
+    unless @tool_lookup.nil?
+      redirect_to @tool_lookup
+      return
+    end
+
     @tool_lookup = Tool.search(@query).to_a
     @tool_lookup = Tool.search(@query.singularize).to_a if @tool_lookup.empty?
     unless @tool_lookup.nil? || @tool_lookup.empty?
       if @tool_lookup.size > 1
-        redirect_to tools_path(tool_type_filter: @tool_lookup[0].tool_type.id)
+        redirect_to tools_path(type_filter: @tool_lookup[0].tool_type.id)
       elsif @tool_lookup.size == 1
         redirect_to @tool_lookup[0]
       end

--- a/app/controllers/tool_types_controller.rb
+++ b/app/controllers/tool_types_controller.rb
@@ -6,11 +6,6 @@ class ToolTypesController < ApplicationController
   def index
   end
 
-  # GET /tool_types/1
-  # GET /tool_types/1.json
-  def show
-  end
-
   # GET /tool_types/new
   def new
   end
@@ -23,7 +18,11 @@ class ToolTypesController < ApplicationController
   # POST /tool_types.json
   def create
     @tool_type.save
-    respond_with(@tool_type)
+    if params[:from_tools].present?
+      redirect_to new_tool_path
+      return
+    end
+    redirect_to tool_types_path
   end
 
   # PATCH/PUT /tool_types/1

--- a/app/controllers/tool_waitlists_controller.rb
+++ b/app/controllers/tool_waitlists_controller.rb
@@ -1,0 +1,58 @@
+class ToolWaitlistsController < ApplicationController
+  # Can't use load_and_authorize_resource until it's fixed in the
+  # checkout controller as well.
+  # load_and_authorize_resource
+
+  # GET /tool_waitlists/new
+  def new
+    @tool_waitlist = ToolWaitlist.new
+    @tool_type = ToolType.find_by_id(params[:tool_type_id])
+    @tool_waitlist.tool_type = @tool
+  end
+
+  # POST /tool_waitlists
+  # POST /tool_waitlists.json
+  def create
+    @tool_waitlist = ToolWaitlist.new({
+        participant_id: params[:participant_id],
+        organization_id: params[:organization_id],
+        tool_type_id: params[:tool_type_id],
+        note: params[:note],
+        wait_start_time: DateTime.now
+    })
+
+    if params[:add].to_i == 1
+      Membership.create({participant_id: params[:participant_id], organization_id: params[:organization_id]})
+    end
+
+    @tool_type = ToolType.find(params[:tool_type_id])
+    if can?(:create, ToolWaitlist) && @tool_waitlist.save
+      redirect_to tools_path(type_filter: @tool_type.id), notice: 'Waitlist entry was successfully created.'
+    else
+      flash[:alert] = @tool_waitlist.errors.full_messages.join(" ")
+      render action: "new"
+    end
+  end
+
+  def choose_organization
+    @tool_type = ToolType.find(params[:tool_type_id])
+    @participant = Participant.find_by_card(params['card-number-input'])
+    @note = params[:note]
+    if @tool_type.blank?
+      redirect_to :back, alert: "Missing tool type"
+    elsif @participant.blank?
+      redirect_to :back, alert: "Missing participant to add to the waitlist"
+    end
+  end
+
+  # DELETE /tool_waitlists/1
+  # DELETE /tool_waitlists/1.json
+  def destroy
+    @tool_waitlist = ToolWaitlist.find(params[:id])
+    if can?(:create, ToolWaitlist) # Creators can destroy any
+      @tool_waitlist.active = false
+      @tool_waitlist.save
+    end
+    redirect_to :back, alert: "Waitlist entry successfully removed"
+  end
+end

--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -4,27 +4,32 @@ class ToolsController < ApplicationController
   # GET /tools
   # GET /tools.json
   def index
-    unless ( params[:organization_id].blank? )
+    unless params[:organization_id].blank?
       @organization = Organization.find(params[:organization_id])
       @tools = Tool.checked_out_by_organization(@organization)
     end
 
-    if (params[:tool_type_filter].present?)
-      @tool_type = ToolType.find(params[:tool_type_filter])
-      @title = @tool_type.name.pluralize
-      @tools = Tool.by_type(@tool_type)
-    elsif (params[:type].blank?)
-      @title = "Tools"
+    # Filter by tools
+    if params[:type_filter].present?
+      if params[:type_filter].strip == 'all_tools'
+        @tools = Tool.all
+        @title = "Tools (hardhats/radios included)"
+      else
+        @tool_type = ToolType.find(params[:type_filter])
+        @title = @tool_type.name.pluralize
+        @tools = Tool.by_type(@tool_type)
+        @waitlist = @tool_type.tool_waitlists.by_wait_start_time
+        @num_available = @tools.size - @tools.checked_out.size
+      end
+    else
       @tools = Tool.just_tools
-    elsif (params[:type] == 'hardhats')
-      @title = "Hardhats"
-      @tools = Tool.hardhats
-    elsif (params[:type] == 'radios')
-      @title = "Radios"
-      @tools = Tool.radios
-    elsif (params[:type] == 'out')
-      @title = "Checked Out"
-      @tools = Tool.just_tools.checked_out
+      @title = "Tools"
+    end
+
+    # Fitler by inventory status
+    if params[:inventory_filter].present?
+      @tools = @tools.checked_out if params[:inventory_filter].strip == 'checked_out'
+      @tools = @tools.checked_in if params[:inventory_filter].strip == 'checked_in'
     end
 
     @tools = @tools.paginate(:page => params[:page]).per_page(20)
@@ -33,6 +38,7 @@ class ToolsController < ApplicationController
   # GET /tools/1
   # GET /tools/1.json
   def show
+    @waitlist = @tool.tool_type.tool_waitlists.by_wait_start_time
   end
 
   # GET /tools/new

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -54,4 +54,14 @@ module ApplicationHelper
     minutes = ((downtime % 3600) + 59) / 60
     return neg + ("%d" % hours) + ":" + ("%02d" % minutes)
   end
+
+  def param_equals_i(param, value)
+    return false if params[param].nil?
+    params[param].to_i == value
+  end
+
+  def param_equals_s(param, value)
+    return false if params[param].nil?
+    params[param].strip == value
+  end
 end

--- a/app/helpers/tool_waitlists_helper.rb
+++ b/app/helpers/tool_waitlists_helper.rb
@@ -1,0 +1,2 @@
+module ToolWaitlistsHelper
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -11,7 +11,7 @@ class Ability
     end
 
     can :read, [OrganizationAlias, OrganizationCategory, Organization, Participant, 
-                ShiftType, Tool, Membership]
+                ShiftType, Tool, ToolWaitlist, Membership]
 
     can :search
 
@@ -78,6 +78,7 @@ class Ability
       can :update, Task
       can [:create, :update], Tool
       can [:create, :update], ToolType
+      can [:create, :update , :destroy], ToolWaitlist
     end
 
     if user.has_role? :admin

--- a/app/models/tool.rb
+++ b/app/models/tool.rb
@@ -39,7 +39,7 @@ class Tool < ActiveRecord::Base
   scope :just_tools, -> { Tool.joins(:tool_type).where("lower(name) NOT LIKE lower(?) AND lower(name) NOT LIKE lower(?)", "%radio", "%hardhat") }
   scope :search, lambda { |term| Tool.joins(:tool_type).where("lower(name) LIKE lower(?) OR CAST(barcode AS CHAR) LIKE lower(?) OR lower(description) LIKE lower(?)", "%#{term}%", "%#{term}%", "%#{term}%") }
   scope :checked_out, -> { Tool.joins(:checkouts).where(checkouts: {checked_in_at: nil}) }
-
+  scope :checked_in, -> { where('tools.id NOT IN (SELECT checkouts.tool_id FROM checkouts WHERE checked_in_at IS NULL)') }
 
   def current_organization
     self.checkouts.current.take.organization unless self.checkouts.current.blank?
@@ -52,9 +52,9 @@ class Tool < ActiveRecord::Base
   def is_checked_out?
     return not(self.checkouts.current.empty?)
   end
-  
+
   def is_hardhat?
-    return self.name.downcase.include?('hardhat') 
+    return self.name.downcase.include?('hardhat')
   end
 
   def self.checked_out_by_organization(organization)

--- a/app/models/tool_type.rb
+++ b/app/models/tool_type.rb
@@ -14,6 +14,7 @@
 
 class ToolType < ActiveRecord::Base
   has_many :tools
+  has_many :tool_waitlists, dependent: :destroy
   validates :name, presence: true, uniqueness: true
 
   default_scope {order(:name)}

--- a/app/models/tool_waitlist.rb
+++ b/app/models/tool_waitlist.rb
@@ -1,0 +1,46 @@
+# ## Schema Information
+#
+# Table name: `tool_waitlists`
+#
+# ### Columns
+#
+# Name                   | Type               | Attributes
+# ---------------------- | ------------------ | ---------------------------
+# **`active`**           | `boolean`          | `default(TRUE)`
+# **`created_at`**       | `datetime`         |
+# **`id`**               | `integer`          | `not null, primary key`
+# **`note`**             | `string(255)`      |
+# **`organization_id`**  | `integer`          |
+# **`participant_id`**   | `integer`          |
+# **`tool_type_id`**     | `integer`          |
+# **`updated_at`**       | `datetime`         |
+# **`wait_start_time`**  | `datetime`         |
+#
+# ### Indexes
+#
+# * `index_tool_waitlists_on_tool_type_id`:
+#     * **`tool_type_id`**
+#
+
+class ToolWaitlist < ActiveRecord::Base
+  # Relationships
+  belongs_to :tool_type
+  belongs_to :organization
+  belongs_to :participant
+
+  # Validations
+  validates_presence_of :tool_type, :organization, :participant, :wait_start_time
+  validates_associated :tool_type, :organization, :participant
+
+  # Scopes
+  default_scope {where(active: true)}
+  scope :for_tool_type, ->(tool_type){where(tool_type: tool_type)}
+  scope :by_wait_start_time, ->{order('wait_start_time')}
+
+  # Gets the time the org has been waiting for the tool in minutes.
+  def duration_waiting
+    (DateTime.current.to_time - wait_start_time.to_time) / 60
+  end
+
+
+end

--- a/app/views/tool_types/_form.html.erb
+++ b/app/views/tool_types/_form.html.erb
@@ -1,8 +1,8 @@
-<%= simple_form_for @tool_type, :html => { :class => 'form-horizontal' } do |f| %>
+<%= simple_form_for @tool_type, html: { class: 'form-horizontal' } do |f| %>
+  <%= hidden_field(nil, :from_tools, :value => params[:from_tools]) %>
   <div class="form-inputs">
     <%= f.input :name %>
   </div>
-
   <div class="form-actions">
     <%= f.button :submit, :class => 'btn-primary' %>
     <%= link_to t('.cancel', :default => t("helpers.links.cancel")),

--- a/app/views/tool_types/index.html.erb
+++ b/app/views/tool_types/index.html.erb
@@ -16,6 +16,9 @@
       <% end %>
       <th>Number of tools with this type</th>
       <th>View tools of this type</th>
+      <% if can?(:create, ToolWaitlist) %>
+        <th>Add to waitlist</th>
+      <% end %>
       <% if can?(:destroy, ToolType) %>
         <th>Delete</th>
       <% end %>
@@ -30,11 +33,15 @@
           <td><%= tool_type.name %></td>
         <% end %>
         <td><%= tool_type.tools.count %></td>
-        <td><%= link_to "View all " + tool_type.name.pluralize, tools_path(tool_type_filter: tool_type.id) %></td>
+        <td><%= link_to "View all " + tool_type.name.pluralize, tools_path(type_filter: tool_type.id) %></td>
+        <% if can?(:create, ToolWaitlist) %>
+          <td><%= link_to "Add to waitlist", new_tool_type_waitlist_path(tool_type), :class => 'btn btn-info btn-xs'  %></td>
+        <% end %>
         <% if can?(:destroy, tool_type) %>
           <td>
             <%= link_to t('.destroy', :default => t("helpers.links.destroy")),
                   tool_type_path(tool_type),
+                  :class => 'btn btn-danger btn-xs',
                   :method => 'delete',
                   :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }%>
           </td>

--- a/app/views/tool_types/show.html.erb
+++ b/app/views/tool_types/show.html.erb
@@ -1,5 +1,0 @@
-<!-- This page technically isn't ever linked to -->
-<p id="notice"><%= notice %></p>
-
-<%= link_to 'Edit', edit_tool_type_path(@tool_type) %> |
-<%= link_to 'Back', tool_types_path %>

--- a/app/views/tool_waitlists/_form.html.erb
+++ b/app/views/tool_waitlists/_form.html.erb
@@ -1,0 +1,14 @@
+<%= simple_form_for '', :html => { :class => 'form-horizontal' }, :url => choose_organization_tool_type_waitlists_path do |f| %>
+	<%= f.input :tool_type_id, :as => :hidden %>
+  <%= f.input :participant_id, required: true do %>
+    <%= f.input_field :participant_id, as: :hidden, required: true %>
+    <%= text_field_tag 'card-number-input', nil, class: 'form-control', required: true %>
+    <div id="participant-info"></div>
+  <% end %>
+  <%= f.input :note, :required => false %>
+  <div class="form-actions">
+    <%= f.button :submit, "Add to waitlist", :class => 'btn-primary' %>
+    <%= link_to t('.cancel', :default => t("helpers.links.cancel")),
+              tools_path, :class => 'btn' %>
+  </div>
+<% end %>

--- a/app/views/tool_waitlists/choose_organization.html.erb
+++ b/app/views/tool_waitlists/choose_organization.html.erb
@@ -1,0 +1,27 @@
+<div class="page-header">
+  <h1>Select Organization
+    <small>(Adding <%= @participant.name %> to waitlist for <%= @tool_type.name.pluralize %> for )</small>
+  </h1>
+</div>
+
+<h2>Current Orgs</h2>
+<br />
+<% @participant.organizations.each do |organization| %>
+  <p>
+  	<%= form_tag tool_type_waitlists_path(@tool_type), :style => "display: inline;" do -%>
+  		<%= hidden_field_tag 'participant_id', @participant.id %>
+      <%= hidden_field_tag 'note', @note %>
+  		<%= hidden_field_tag 'organization_id', organization.id %>
+  	  <%= submit_tag organization.name, :class => 'btn btn-success' %>
+  	<% end -%>
+  </p>
+<% end %>
+<br />
+<h2>Other Orgs</h2>
+<%= simple_form_for '', url: tool_type_waitlists_path(@tool_type) do |f| %>
+  <%= f.input :participant_id, :input_html => { :value => @participant.id }, :as => :hidden %>
+  <%= f.input :note, :input_html => { :value => @note}, :as => :hidden %>
+  <%= f.input :organization_id, :as => :select, :collection => Organization.all %>
+  <%= f.input 'add', :label => "Add Membership", :as => :boolean %>
+  <%= submit_tag "Submit", :class => 'btn btn-primary' %>
+<% end -%>

--- a/app/views/tool_waitlists/new.html.erb
+++ b/app/views/tool_waitlists/new.html.erb
@@ -1,0 +1,6 @@
+<%- model_class = ToolWaitlist -%>
+<div class="page-header">
+  <h1>Add to waitlist for <%= @tool_type.name.pluralize %></h1>
+</div>
+
+<%= render :partial => 'form' %>

--- a/app/views/tools/_form.html.erb
+++ b/app/views/tools/_form.html.erb
@@ -8,7 +8,7 @@
                 :selected => @tool.tool_type.nil? ? '' : @tool.tool_type.id %>
         </div>
         <div>
-          <%= link_to "Or create a new tool type", new_tool_type_path, class: 'btn btn-primary' %>
+          <%= link_to "Or create a new tool type", new_tool_type_path(from_tools: true), class: 'btn btn-primary' %>
         </div>
       </div>
       <div class='row'>

--- a/app/views/tools/_tool_waitlist.html.erb
+++ b/app/views/tools/_tool_waitlist.html.erb
@@ -1,0 +1,39 @@
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Position</th>
+      <th>Person</th>
+      <th>Organization</th>
+      <th>Wait duration (Minutes)</th>
+      <th>Note</th>
+      <% if can?(:destroy, ToolWaitlist) %>
+        <th>Remove</th>
+      <% end %>
+    </tr>
+  </thead>
+  <tbody>
+    <% @waitlist.each_with_index do |waitlist, index| %>
+      <tr>
+        <td><%= index + 1 %></td>
+        <td><%= "#{waitlist.participant.name} (#{waitlist.participant.andrewid})" %></td>
+        <td><%= link_to waitlist.organization.short_name, organization_path(waitlist.organization) %></td>
+        <td><%= "#{waitlist.duration_waiting.to_i} mins" %></td>
+        <td><%= waitlist.note %></td>
+        <% if can?(:destroy, ToolWaitlist) %>
+          <td>
+            <%= link_to "Remove",
+                tool_type_waitlist_path(waitlist.tool_type, waitlist),
+                :class => 'btn btn-danger btn-xs',
+                :method => 'delete',
+                :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }%>
+          </td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+<% if @waitlist.empty? %>
+  <div class="alert alert-info">
+      <span>There is no one waiting for this type of tool!</span>
+  </div>
+<% end %>

--- a/app/views/tools/_tool_waitlist.html.erb
+++ b/app/views/tools/_tool_waitlist.html.erb
@@ -4,10 +4,12 @@
       <th>Position</th>
       <th>Person</th>
       <th>Organization</th>
-      <th>Wait duration (Minutes)</th>
-      <th>Note</th>
+      <th class="hidden-xs">Wait duration (Minutes)</th>
+      <% if can?(:create, ToolWaitlist) %>
+        <th class="hidden-xs">Note</th>
+      <% end %>
       <% if can?(:destroy, ToolWaitlist) %>
-        <th>Remove</th>
+        <th class="hidden-xs">Remove</th>
       <% end %>
     </tr>
   </thead>
@@ -17,10 +19,12 @@
         <td><%= index + 1 %></td>
         <td><%= "#{waitlist.participant.name} (#{waitlist.participant.andrewid})" %></td>
         <td><%= link_to waitlist.organization.short_name, organization_path(waitlist.organization) %></td>
-        <td><%= "#{waitlist.duration_waiting.to_i} mins" %></td>
-        <td><%= waitlist.note %></td>
-        <% if can?(:destroy, ToolWaitlist) %>
-          <td>
+        <td  class="hidden-xs"><%= "#{waitlist.duration_waiting.to_i} mins" %></td>
+        <% if can?(:create, ToolWaitlist) %>
+          <td  class="hidden-xs"><%= waitlist.note %></td>
+        <% end %>
+        <% if can?(:approve, Charge) %>
+          <td class="hidden-xs">
             <%= link_to "Remove",
                 tool_type_waitlist_path(waitlist.tool_type, waitlist),
                 :class => 'btn btn-danger btn-xs',

--- a/app/views/tools/_tools.html.erb
+++ b/app/views/tools/_tools.html.erb
@@ -19,3 +19,11 @@
     <% end %>
   </tbody>
 </table>
+
+<% if tools.empty? %>
+  <div class="alert alert-info">
+      There are no <%= param_equals_s(:inventory_filter, 'checked_out') ? raw('<strong>Checked Out</strong>') : '' %>
+    <%= param_equals_s(:inventory_filter, 'checked_in') ? raw('<strong>Checked In</strong>') : '' %>
+   <%= @title %> at this time. <%= link_to raw("<strong>See All #{@title}</strong>"), tools_path(type_filter: params[:type_filter]) %>
+  </div>
+<% end %>

--- a/app/views/tools/index.html.erb
+++ b/app/views/tools/index.html.erb
@@ -7,28 +7,68 @@
 </div>
 
 <div>
-  <div style='float: left; border: 1px solid #ccc; border-radius: 4px; padding: 6px; margin-right: 8px;'>
-    <span style='font-weight: bold; margin-right: 5px'>Filter by Tool Type: </span>
-    <form action='<%= tools_path %>' method='get'>
-      <select name='tool_type_filter' onchange='this.form.submit()'>
-        <option value='' <%= @tool_type.nil? ? 'selected' : ''%> disabled>Select a tool type</option>
+  <form action='<%= tools_path %>' method='get'>
+    <div style='float: left; border: 1px solid #ccc; border-radius: 4px; padding: 6px; margin-right: 8px;'>
+      <span style='font-weight: bold; margin-right: 5px'>Filter by Tool Type</span><br />
+      <select name='type_filter' class='form-control' onchange='this.form.submit()'>
+        <%= raw("<option value='' #{params[:type_filter].present? ? '':'selected'}>All tools</option>") %>
+        <%= raw("<option value='all_tools' #{param_equals_s(:type_filter, 'all_tools') ? 'selected':''}>All tools (Include hardhats/radios)</option>") %>
         <% ToolType.all.to_a.each do |tool_type| %>
-          <%= raw("<option value='#{tool_type.id}' #{@tool_type.present? && (@tool_type.id == tool_type.id) ? 'selected' : ''}>#{tool_type.name}</option>") %>
+          <%= raw("<option value='#{tool_type.id}' #{param_equals_i(:type_filter, tool_type.id) ? 'selected' : ''}>#{tool_type.name}</option>") %>
         <% end %>
       </select>
-    </form>
-  </div>
-  <%= link_to raw("Tools"), tools_path, :class => 'btn btn-default' unless (params[:type].blank? && params[:tool_type_filter].blank?) or !@organization.blank? %>
-  <%= link_to raw("Hardhats"), tools_path(:type => "hardhats"), :class => 'btn btn-default' unless params[:type] == 'hardhats' or !@organization.blank? %>
-  <%= link_to raw("Radios"), tools_path(:type => "radios"), :class => 'btn btn-default' unless params[:type] == 'radios' or !@organization.blank? %>
-  <%= link_to raw("Checked Out"), tools_path(:type => "out"), :class => 'btn btn-default' unless params[:type] == 'out' or !@organization.blank? %>
+      </div>
+    <div style='float: left; border: 1px solid #ccc; border-radius: 4px; padding: 6px; margin-right: 8px;'>
+      <span style='font-weight: bold; margin-right: 5px'>Filter Checked Out Status </span><br />
+      <select name='inventory_filter' class='form-control' onchange='this.form.submit()'>
+        <option value='' <%= @tool_type.nil? ? 'selected' : ''%> disabled>Select a tool type</option>
+        <%= raw("<option value='' #{params[:inventory_filter].present? ? '':'selected'}>All</option>") %>
+        <%= raw("<option value='checked_in' #{(params[:inventory_filter].present? && params[:inventory_filter] == 'checked_in') ? 'selected':''}>Checked In Only</option>") %>
+        <%= raw("<option value='checked_out' #{(params[:inventory_filter].present? && params[:inventory_filter] == 'checked_out') ? 'selected':''}>Checked Out Only</option>") %>
+      </select>
+    </div>
+  </form>
+  <%= link_to raw("Reset"), tools_path, :class => 'btn btn-default' %>
   <% if can?(:create, Tool) and @organization.blank? %>
     <%= link_to t('.new', :default => t("helpers.links.new")),
             new_tool_path,
             :class => 'btn btn-primary' %>
   <% end %>
 </div>
+<br />
+<br />
+<% if @tool_type.present? && (@waitlist.present? || @num_available < 1) %>
+    <div class="alert alert-info alert-inline">
+      <div class="row">
+        <div class="col-xs-7">
+          <% if @waitlist.present? %>
+            There <%= "#{@waitlist.size == 1 ? 'is' : 'are'}" %> <%= pluralize(@waitlist.size, 'person') %> waiting for <%= @title %>.
+          <% else %>
+            All <%= @title %> are checked out!
+          <% end %>
+        </div>
+        <div class="col-xs-2">
+          <% if @waitlist.present? %>
+            <a href="#tool-type-waitlist" class="btn btn-info btn-sm" data-toggle="collapse">Show/Hide Waitlist</a>
+          <% end %>
+        </div>
+        <div class="col-xs-1"></div>
+        <div class="col-xs-2">
+          <% if can?(:create, ToolWaitlist) %>
+            <%= link_to raw("<strong>Add to Waitlist</strong>"), new_tool_type_waitlist_path(@tool_type),
+                        class: "btn btn-warning btn-sm" %>
+          <% end %>
+        </div>
+      </div>
+    </div>
 
+    <% if @waitlist.present? %>
+      <div id="tool-type-waitlist" class="collapse out">
+        <h3><%= @title %> Waitlist</h3>
+        <%= render partial: 'tool_waitlist' %>
+      </div>
+    <% end %>
+<% end %>
 <%= render partial: 'tools', locals: {tools: @tools} %>
 
 <%= will_paginate @tools, renderer: BootstrapPagination::Rails %>

--- a/app/views/tools/show.html.erb
+++ b/app/views/tools/show.html.erb
@@ -31,7 +31,9 @@
                     new_tool_checkout_path(@tool), :class => 'btn btn-warning' %>
   <% end %>
 <% end %>
-
+<% if can?(:create, ToolWaitlist) %>
+  <%= link_to "Add to Waitlist", new_tool_type_waitlist_path(@tool.tool_type), class: 'btn btn-info' %>
+<% end %>
 <% if can?(:update, @tool) %>
   <%= link_to t('.edit', :default => t("helpers.links.edit")),
           edit_tool_path(@tool), :class => 'btn btn-primary' %>
@@ -42,4 +44,11 @@
           :method => 'delete',
           :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
           :class => 'btn btn-danger' %>
+<% end %>
+<% if can?(:read, ToolWaitlist) %>
+  <br /><br />
+  <div>
+    <h3>Waitlist for All <%= @tool.tool_type.name.pluralize %></h3>
+    <%= render partial: 'tool_waitlist' %>
+  </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,12 @@ Trailerapp::Application.routes.draw do
       post 'choose_organization', on: :collection
     end
   end
-  resources :tool_types
+
+  resources :tool_types , :except => [:show] do
+    resources :tool_waitlists, :only => [:new, :create, :destroy], :as => :waitlists do
+      post 'choose_organization', on: :collection
+    end
+  end
 
   resources :checkouts, :only => [:create] do
     post 'checkin', on: :collection

--- a/db/migrate/20160215065501_create_tool_waitlists.rb
+++ b/db/migrate/20160215065501_create_tool_waitlists.rb
@@ -1,0 +1,14 @@
+class CreateToolWaitlists < ActiveRecord::Migration
+  def change
+    create_table :tool_waitlists do |t|
+      t.references :tool_type, index: true
+      t.datetime :wait_start_time
+      t.references :participant
+      t.references :organization
+      t.string :note
+      t.boolean :active, default: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160208180433) do
+ActiveRecord::Schema.define(version: 20160215065501) do
 
   create_table "charge_types", force: :cascade do |t|
     t.string   "name",                          limit: 255
@@ -271,6 +271,19 @@ ActiveRecord::Schema.define(version: 20160208180433) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  create_table "tool_waitlists", force: :cascade do |t|
+    t.integer  "tool_type_id",    limit: 4
+    t.datetime "wait_start_time"
+    t.integer  "participant_id",  limit: 4
+    t.integer  "organization_id", limit: 4
+    t.string   "note",            limit: 255
+    t.boolean  "active",          limit: 1,   default: true
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "tool_waitlists", ["tool_type_id"], name: "index_tool_waitlists_on_tool_type_id", using: :btree
 
   create_table "tools", force: :cascade do |t|
     t.integer  "barcode",      limit: 4

--- a/test/fixtures/tool_waitlists.yml
+++ b/test/fixtures/tool_waitlists.yml
@@ -1,0 +1,19 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  waiting_on_id: 1
+  is_specific_tool: false
+  wait_start_time: 2016-02-15 01:55:01
+  participant_id: 1
+  organization_id: 1
+  contact_method: MyString
+  active: false
+
+two:
+  waiting_on_id: 1
+  is_specific_tool: false
+  wait_start_time: 2016-02-15 01:55:01
+  participant_id: 1
+  organization_id: 1
+  contact_method: MyString
+  active: false

--- a/test/unit/tool_waitlist_test.rb
+++ b/test/unit/tool_waitlist_test.rb
@@ -1,0 +1,31 @@
+# ## Schema Information
+#
+# Table name: `tool_waitlists`
+#
+# ### Columns
+#
+# Name                   | Type               | Attributes
+# ---------------------- | ------------------ | ---------------------------
+# **`active`**           | `boolean`          | `default(TRUE)`
+# **`created_at`**       | `datetime`         |
+# **`id`**               | `integer`          | `not null, primary key`
+# **`note`**             | `string(255)`      |
+# **`organization_id`**  | `integer`          |
+# **`participant_id`**   | `integer`          |
+# **`tool_type_id`**     | `integer`          |
+# **`updated_at`**       | `datetime`         |
+# **`wait_start_time`**  | `datetime`         |
+#
+# ### Indexes
+#
+# * `index_tool_waitlists_on_tool_type_id`:
+#     * **`tool_type_id`**
+#
+
+require 'test_helper'
+
+class ToolWaitlistTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This pull request is part 3/3 of tool refactoring + tool waitlist bigger PR that was split up.

This PR adds the tool waitlist features as well as fixes a few minor bugs with tool types that the tool waitlist depended on.

This resolves issue #101.


CHANGE LOG:
Scaffoled tool waitlists

Removed tool waitlist controller tests

Removed waiting on specific tools

Fixed bug for searching for tools with similar barcodes

Only show waitlist for tool types on tool show page

Added helper to quickly check params

Updated tool filtering for the addition of tool types

Refactored tool waitlist to only wait on types of tools. Updated display of tool waitlists.

Removed unused show action from tool types controller

Ensure that tool type waitlists are destroyed when their parent tool type is destroyed

Updated routes for tool types/tool waitlists. Updated views accordingly

Added support for creating tool waitlists (based on checkout process)

Updated tool index/show views to incorporate waitlists

Fixed bug with destory waitlist items

Updated wording of waitlists dialog

Updated filter selects to use bootstrap style

Added message if there is no one on the waitlist. Fixed overlaping ui

Waitlist entries are automatically removed on checkout to right person

Renamed contact method to note and made it optional

Fixed bug with searching for tools by type

Fixed bug with linking to tool by types

Added checked in scope to tools index

** UPDATED **
Removal from tool waitlist on checkout is only based on organization

Fixed bug with participants not being able to view waitlists

Fixed bug with using flash alerts vs notices on errors