### PR TITLE
Improve cancel button links in form partials

### DIFF
--- a/app/views/charges/_form.html.erb
+++ b/app/views/charges/_form.html.erb
@@ -32,7 +32,7 @@ When adding a charge, please ensure that you add a detailed description. This al
   <div class="form-actions">
     <%= f.button :submit, :class => 'btn-primary' %>
     <%= link_to t('.cancel', :default => t("helpers.links.cancel")),
-              charges_path, :class => 'btn btn-default' %>
+              @charge, :class => 'btn btn-default' %>
   </div>
 <% end %>
 

--- a/app/views/checkouts/_form.html.erb
+++ b/app/views/checkouts/_form.html.erb
@@ -8,6 +8,6 @@
   <div class="form-actions">
     <%= f.button :submit, "Check Tool Out", :class => 'btn-primary' %>
     <%= link_to t('.cancel', :default => t("helpers.links.cancel")),
-              tools_path, :class => 'btn' %>
+              @tool, :class => 'btn btn-default' %>
   </div>
 <% end %>

--- a/app/views/documents/_form.html.erb
+++ b/app/views/documents/_form.html.erb
@@ -10,6 +10,6 @@
   <div class="form-actions">
     <%= f.button :submit, :class => 'btn-primary' %>
     <%= link_to t('.cancel', :default => t("helpers.links.cancel")),
-              documents_path, :class => 'btn btn-default' %>
+              @document, :class => 'btn btn-default' %>
   </div>
 <% end %>

--- a/app/views/faqs/_form.html.erb
+++ b/app/views/faqs/_form.html.erb
@@ -7,6 +7,6 @@
   <div class="form-actions">
     <%= f.button :submit, :class => 'btn-primary' %>
     <%= link_to t('.cancel', :default => t("helpers.links.cancel")),
-              faqs_path, :class => 'btn btn-default' %>
+              @faq, :class => 'btn btn-default' %>
   </div>
 <% end %>

--- a/app/views/memberships/edit.html.erb
+++ b/app/views/memberships/edit.html.erb
@@ -12,6 +12,6 @@
   <div class="form-actions">
     <%= f.button :submit, :class => 'btn-primary' %>
     <%= link_to t('.cancel', :default => t("helpers.links.cancel")),
-              participant_path(@participant), :class => 'btn btn-default' %>
+              @participant, :class => 'btn btn-default' %>
   </div>
 <% end %>

--- a/app/views/memberships/new.html.erb
+++ b/app/views/memberships/new.html.erb
@@ -40,6 +40,6 @@
   <div class="form-actions">
     <%= f.button :submit, :class => 'btn-primary' %>
     <%= link_to t('.cancel', :default => t("helpers.links.cancel")),
-        participant_path(@participant), :class => 'btn btn-default' %>
+        @participant, :class => 'btn btn-default' %>
   </div>
 <% end %>

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -8,6 +8,6 @@
   <div class="form-actions">
     <%= f.button :submit, :class => 'btn-primary' %>
     <%= link_to t('.cancel', :default => t("helpers.links.cancel")),
-              organizations_path, :class => 'btn btn-default' %>
+              @organization, :class => 'btn btn-default' %>
   </div> 
 <% end %>

--- a/app/views/participants/_form.html.erb
+++ b/app/views/participants/_form.html.erb
@@ -8,7 +8,7 @@
   <div class="form-actions">
     <%= f.button :submit, :class => 'btn-primary' %>
     <%= link_to t('.cancel', :default => t("helpers.links.cancel")),
-              participants_path, :class => 'btn btn-default' %>
+              @participant, :class => 'btn btn-default' %>
   </div>
 <% end %>
 

--- a/app/views/shifts/_form.html.erb
+++ b/app/views/shifts/_form.html.erb
@@ -11,6 +11,6 @@
   <div class="form-actions">
     <%= f.button :submit, :class => 'btn-primary' %>
     <%= link_to t('.cancel', :default => t("helpers.links.cancel")),
-                shifts_path, :class => 'btn btn-default' %>
+                @shift, :class => 'btn btn-default' %>
   </div>
 <% end %>

--- a/app/views/store/items/_form.html.erb
+++ b/app/views/store/items/_form.html.erb
@@ -8,6 +8,6 @@
 <div class="form-actions">
   <%= f.button :submit, :class => 'btn-primary' %>
   <%= link_to t('.cancel', :default => t("helpers.links.cancel")),
-  store_items_path, :class => 'btn btn-default' %>
+  @store_item, :class => 'btn btn-default' %>
 </div>
 <% end %>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -10,6 +10,6 @@
   <div class="form-actions">
     <%= f.button :submit, :class => 'btn-primary' %>
     <%= link_to t('.cancel', :default => t("helpers.links.cancel")),
-              tasks_path, :class => 'btn btn-default' %>
+              @task, :class => 'btn btn-default' %>
   </div>
 <% end %>

--- a/app/views/tool_waitlists/_form.html.erb
+++ b/app/views/tool_waitlists/_form.html.erb
@@ -9,6 +9,6 @@
   <div class="form-actions">
     <%= f.button :submit, "Add to waitlist", :class => 'btn-primary' %>
     <%= link_to t('.cancel', :default => t("helpers.links.cancel")),
-              tools_path, :class => 'btn' %>
+              @tool, :class => 'btn btn-default' %>
   </div>
 <% end %>

--- a/app/views/tools/_form.html.erb
+++ b/app/views/tools/_form.html.erb
@@ -25,7 +25,7 @@
   <div class="form-actions">
     <%= f.button :submit, :class => 'btn-primary' %>
     <%= link_to t('.cancel', :default => t("helpers.links.cancel")),
-              tool_path(@tool), :class => 'btn btn-default' %>
+             @tool, :class => 'btn btn-default' %>
   </div>
 <% end %>
 


### PR DESCRIPTION
Change all "Cancel" and "Back" buttons to use the ":back" path.  This resolves issue with views using the same form partial for edit (where "Back" needs to redirect to the show view) and new.  (where "Cancel" need to direct to the index view).  This is more natural to users and will prevent future problems if we decide to add new, edit, or show links in less canonical places.