### PR TITLE
Rapid Tool cart feature

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -46,4 +46,4 @@ $(document).on("ready page:change", function(){
       $(':submit').focus()
     }
   });
-})
+});

--- a/app/assets/javascripts/tool_cart.js
+++ b/app/assets/javascripts/tool_cart.js
@@ -129,6 +129,8 @@ var ToolCart = new function(){
           cko_participant['member_orgs'].forEach(function(org){
             $cko_organization_select.first().append('<option value="' + org['id'] + '">' + org['name'] + '</option>');
           });
+          // Add blank line
+          $cko_organization_select.first().append('<option value="" disabled></option>');
         }
         $cko_organization_select.append('<optgroup label="All Organizations"></optgroup>');
         cko_participant['non_member_orgs'].forEach(function(org){

--- a/app/assets/javascripts/tool_cart.js
+++ b/app/assets/javascripts/tool_cart.js
@@ -1,0 +1,176 @@
+var ToolCart = new function(){
+  // Panel selectors
+  var $scan_tools_action,
+      $checkout_action;
+
+  // Scan tool action selectors
+  var $scan_tool_input,
+      $scan_tool_list,
+      $scan_tool_list_table;
+
+  // Checkout action selectors
+  var $cko_tools_count,
+      $cko_andrewid_input,
+      $cko_loaded_participant_div,
+      $cko_loaded_participant,
+      $cko_loaded_participant_id,
+      $cko_organization_select,
+      $cko_add_membership_div,
+      $cko_add_membership_ckb;
+
+  this.initSidebarWidget = function(){
+    // Panels
+    $scan_tools_action = $('#tc_scan_tools_action');
+    $checkout_action = $('#tc_checkout_action');
+
+    // Scan tool action selectors
+    $scan_tool_input = $('#tc_scan_tool');
+    $scan_tool_list = $('#tc_tool_list');
+    $scan_tool_list_table = $('#tc_tool_list_container');
+
+    // Checkout action selectors
+    $cko_tools_count = $('#tc_checkout_tools_count');
+    $cko_andrewid_input = $('#tc_checkout_scan_andrewid');
+    $cko_loaded_participant_div = $('#tc_checkout_loaded_participant_div');
+    $cko_loaded_participant = $('#tc_checkout_loaded_participant');
+    $cko_loaded_participant_id = $('#tc_checkout_loaded_participant_id');
+    $cko_organization_select = $('#tc_checkout_select_organization');
+    $cko_add_membership_div = $('#tc_checkout_add_membership_div');
+    $cko_add_membership_ckb = $('#tc_checkout_add_membership');
+
+    bindCheckoutEvents();
+    bindScanEvents();
+
+    $('[data-toggle="tooltip"]').tooltip();
+    ToolCart.scanToolsAction();
+  };
+
+  // Scan tool Methods
+  this.scanToolsAction = function(){
+    $checkout_action.hide();
+    $scan_tools_action.show();
+    $scan_tool_input.focus();
+
+    // Reset checkout action
+    $cko_andrewid_input.val('');
+    $cko_loaded_participant.html('');
+    $cko_loaded_participant_id.val('');
+    $cko_loaded_participant_div.hide();
+    $cko_organization_select.empty();
+    $cko_add_membership_ckb.attr('checked', false);
+    $cko_add_membership_div.hide();
+  };
+
+  function bindScanEvents(){
+    // Bind event handler for scanning tools
+    $scan_tool_input.bind("keydown", function(event) {
+      if (event && event.keyCode == 13) {
+        event.preventDefault();
+        $scan_tool_input.closest('form').trigger('submit');
+      }
+    });
+  }
+
+  // Checkout Methods
+  this.checkoutAction = function(){
+    var scannedToolsCount = $scan_tool_list.find('.cart-item').length,
+        countSuffix = scannedToolsCount == 1 ? 'tool' : 'tools';
+
+    if(scannedToolsCount < 1){
+      ToolCart.showAlert('Scan some tools to checkout first.', false, 1500);
+      $scan_tool_input.val('');
+      $scan_tool_input.focus();
+    }else{
+      $scan_tools_action.hide();
+      $cko_tools_count.html(scannedToolsCount + ' ' + countSuffix);
+      $checkout_action.show();
+      $cko_andrewid_input.focus();
+    }
+  };
+
+  function bindCheckoutEvents(){
+    // Bind event handler to org select to show or hide add membership option.
+    $cko_organization_select.bind('change', function(){
+      if($cko_organization_select.find('option:selected').attr('data-nonmember')){
+        $cko_add_membership_div.show();
+      }else{
+        $cko_add_membership_ckb.attr('checked', false);
+        $cko_add_membership_div.hide();
+      }
+    });
+
+    // Bind checkout action events
+    $cko_andrewid_input.bind("keydown", function(e){
+      if(e.keyCode != 13) return;
+      e.preventDefault();
+      $.ajax({
+        url: "/participants/lookup.json",
+        type: "POST",
+        data: {
+          card_number: $cko_andrewid_input.val()
+        }
+      }).done( function(data) {
+        var cko_participant = data;
+
+        // Update the participant name.
+        $cko_loaded_participant.html(cko_participant['name']);
+        $cko_loaded_participant_id.val(cko_participant['id']);
+        $cko_loaded_participant_div.fadeIn(500);
+
+        // Reset the organization options
+        $cko_organization_select.empty();
+        $cko_add_membership_ckb.attr('checked', false);
+        $cko_add_membership_div.hide();
+
+        // Populate the organization select with options.
+        if(cko_participant['member_orgs'].length > 0){
+          $cko_organization_select.append('<optgroup label="Orgs ' + cko_participant['name'] +
+                              ' is in" id="tc_checkout_select_member_orgs_group"></optgroup>');
+          cko_participant['member_orgs'].forEach(function(org){
+            $cko_organization_select.first().append('<option value="' + org['id'] + '">' + org['name'] + '</option>');
+          });
+        }
+        $cko_organization_select.append('<optgroup label="All Organizations"></optgroup>');
+        cko_participant['non_member_orgs'].forEach(function(org){
+          $cko_organization_select.last().append('<option value="' + org['id'] + '" data-nonmember="true">' + org['name'] + '</option>');
+        });
+
+        if(cko_participant['member_orgs'].length == 0) $cko_add_membership_div.show();
+      }).error( function(data) {
+        ToolCart.showAlert('Could not load person\'s information. Try manually entering their Andrew ID or ask for help.', false, 4500);
+      });
+    });
+  }
+
+
+  // Public Utility Methods
+  var alertTimeout = null;
+  this.showAlert = function(message, isSuccess, delay){
+    var $alert = $('#tc_alert');
+
+    if(isSuccess){
+      $alert.removeClass('alert-danger').addClass('alert-success');
+    }else{
+      $alert.removeClass('alert-success').addClass('alert-danger');
+    }
+
+    if(alertTimeout) clearTimeout(alertTimeout);
+    $('#tc_alert_message').html(message);
+    $alert.stop();
+    $alert.hide();
+    $alert.fadeIn(250);
+    alertTimeout = setTimeout(function(){
+      $alert.fadeOut(500);
+      alertTimeout = null;
+    }, delay);
+  };
+
+  this.clearCartItems = function(){
+    $('#tc_tool_list').empty();
+    $('#tc_tool_list_container').hide();
+  };
+
+
+
+
+};

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -41,3 +41,10 @@ body {
 .cart-warning{
   background-color: #fcf3dd;
 }
+
+.cart-button{
+  width: 33%;
+  white-space: normal;
+  height: 55px;
+  border-color: #1d4b97;
+}

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -22,3 +22,22 @@ body {
   margin: 4px;
   padding: 10px;
 }
+
+.full-width{
+  width: 100%;
+}
+
+.cart-item{
+  padding: 8px 4px 8px 4px;
+  border-top: 1px solid lightgrey;
+  width: 100%;
+  margin: 0;
+}
+
+.cart-item div{
+  padding: 0;
+}
+
+.cart-warning{
+  background-color: #fcf3dd;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,8 +45,9 @@ class ApplicationController < ActionController::Base
     @tasks_sidebar = Task.upcoming.is_incomplete
     @structural_queue_sidebar = OrganizationTimelineEntry.structural.current
     @electrical_queue_sidebar = OrganizationTimelineEntry.electrical.current
-
     @downtime_sidebar = OrganizationTimelineEntry.downtime.current
+    session[:tool_cart] = session[:tool_cart] || []
+    @tool_cart = session[:tool_cart].map{|barcode| Tool.find_by_barcode(barcode)}.reverse
   end
 
   def require_authenticated_user

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -20,7 +20,11 @@ class ParticipantsController < ApplicationController
     participant = Participant.find_by_card params[:card_number]
     
     unless participant.blank?
-      render json: { :id => participant.id, :name => participant.name }
+      render json: { :id => participant.id,
+                     :name => participant.name,
+                     :member_orgs => participant.organizations,
+                     :non_member_orgs => Organization.all.select{|org| !participant.organizations.include?(org)}
+      }
     else
       render json: :nothing, status: :unprocessable_entity
     end

--- a/app/controllers/tool_cart_controller.rb
+++ b/app/controllers/tool_cart_controller.rb
@@ -1,0 +1,184 @@
+class ToolCartController < ApplicationController
+  before_action :check_permissions
+
+  def add_tool
+    @tool = Tool.find_by_barcode(params[:barcode])
+    session[:tool_cart] = session[:tool_cart] || []
+
+    unless @tool.present?
+      return render action: 'tool_cart_error',
+                    locals: {message: 'Could not load that tool. Try scanning it again or add the tool to the system.'}
+    end
+
+    if session[:tool_cart].include?(@tool.barcode)
+      return render action: 'tool_cart_error',
+                    locals: {message: "Tool ##{@tool.barcode} is already in the cart"}
+    end
+
+    session[:tool_cart].append(@tool.barcode)
+    render action: 'add_tool'
+  end
+
+  def remove_tool
+    session[:tool_cart] = session[:tool_cart] || []
+
+    unless session[:tool_cart].include?(params[:barcode].to_i)
+      return render action: 'tool_cart_error',
+                    locals: {message: "Tool is not in the cart"}
+    end
+
+    session[:tool_cart].delete(params[:barcode].to_i)
+    render action: 'remove_tool', locals: {barcode: params[:barcode], list_empty: session[:tool_cart].empty?}
+  end
+
+  def checkout
+    session[:tool_cart] = session[:tool_cart] || []
+    if session[:tool_cart].empty?
+      return render action: 'tool_cart_error',
+                    locals: {message: "Scan tools to checkout first"}
+    end
+
+    if params[:participant_id].empty? || params[:organization_id].empty?
+      return render action: 'tool_cart_error',
+                    locals: {message: "Enter a valid participant and org. (Try pressing enter inside the input box)"}
+    end
+    participant = Participant.find(params[:participant_id])
+    organization = Organization.find(params[:organization_id])
+
+    # Validations
+    unless participant.present?
+      return render action: 'tool_cart_error',
+                    locals: {message: "Invalid participant"}
+    end
+
+    unless organization.present?
+      return render action: 'tool_cart_error',
+                    locals: {message: "Invalid organization"}
+    end
+
+    # Add membership
+    if params[:add_membership]
+      Membership.create({participant_id: params[:participant_id], organization_id: params[:organization_id]})
+    end
+
+    # Create checkouts
+    session[:tool_cart].each do |barcode|
+      tool = Tool.find_by_barcode(barcode)
+      next if tool.blank?
+
+      # Checkin tool if it is already checked out
+      if tool.is_checked_out?
+        old_checkout = tool.checkouts.current.first
+        old_checkout.checked_in_at = Time.now
+        old_checkout.save
+      end
+
+      checkout = Checkout.new
+      checkout.checked_out_at = Time.now
+      checkout.tool = tool
+      checkout.participant = participant
+      checkout.organization = organization
+
+      if checkout.save
+        checkout.tool.tool_type.tool_waitlists.each do |waitlist|
+          if waitlist.organization == checkout.organization
+            # Automatically remove the person from the waitlist
+            waitlist.active = false
+            waitlist.save
+            break
+          end
+        end
+      end
+    end
+
+    @num_tools = session[:tool_cart].size
+    @person_name = participant.andrewid
+    @org_name = organization.short_name
+
+    session[:tool_cart] = []
+  end
+
+  def checkin
+    session[:tool_cart] = session[:tool_cart] || []
+    if session[:tool_cart].empty?
+      return render action: 'tool_cart_error',
+                    locals: {message: "Scan tools to checkin first"}
+    end
+
+
+    session[:tool_cart].each do |barcode|
+      tool = Tool.find_by_barcode(barcode)
+      next if tool.blank?
+
+      # Checkin tool if it is already checked out
+      if tool.is_checked_out?
+        old_checkout = tool.checkouts.current.first
+        old_checkout.checked_in_at = Time.now
+        old_checkout.save
+      end
+    end
+
+    @num_tools = session[:tool_cart].size
+    session[:tool_cart] = []
+  end
+
+  def swap
+    session[:tool_cart] = session[:tool_cart] || []
+    if session[:tool_cart].size != 2
+      return render action: 'tool_cart_error',
+                    locals: {message: "You must scan exactly 1 checked in tool and 1 checked out tool to use swap."}
+    end
+
+    first_tool = Tool.find_by_barcode(session[:tool_cart][0])
+    second_tool = Tool.find_by_barcode(session[:tool_cart][1])
+
+    if first_tool.is_checked_out? && !second_tool.is_checked_out?
+      checkedin_tool = second_tool
+      checkedout_tool = first_tool
+    elsif second_tool.is_checked_out? && !first_tool.is_checked_out?
+      checkedin_tool = first_tool
+      checkedout_tool = second_tool
+    else
+      return render action: 'tool_cart_error',
+                    locals: {message: "You must scan exactly 1 checked in tool and 1 checked out tool to use swap."}
+    end
+
+    @old_tool_name = checkedout_tool.name
+    @new_tool_name = checkedin_tool.name
+    @person_name = checkedout_tool.current_participant.name
+    @org_name = checkedout_tool.current_organization.short_name
+
+    # Checkout new tool
+    checkout = Checkout.new
+    checkout.checked_out_at = Time.now
+    checkout.tool = checkedin_tool
+    checkout.participant = checkedout_tool.current_participant
+    checkout.organization = checkedout_tool.current_organization
+
+    if checkout.save
+      checkout.tool.tool_type.tool_waitlists.each do |waitlist|
+        if waitlist.organization == checkout.organization
+          # Automatically remove the person from the waitlist
+          waitlist.active = false
+          waitlist.save
+          break
+        end
+      end
+    end
+
+    # Checkin old tool
+    old_checkout = checkedout_tool.checkouts.current.first
+    old_checkout.checked_in_at = Time.now
+    old_checkout.save
+
+    session[:tool_cart] = []
+  end
+
+  private
+  def check_permissions
+    unless can?(:create, Checkout)
+      redirect_to root_url, alert: 'You do not have permission to use the tool cart'
+    end
+  end
+
+end

--- a/app/controllers/tool_types_controller.rb
+++ b/app/controllers/tool_types_controller.rb
@@ -18,7 +18,11 @@ class ToolTypesController < ApplicationController
   # POST /tool_types
   # POST /tool_types.json
   def create
-    @tool_type.save
+    unless @tool_type.save
+      respond_with(@tool_type)
+      return
+    end
+
     if params[:from_tools].present?
       redirect_to new_tool_path
       return

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -88,7 +88,7 @@
 
   <%# Change to true to enable the quick links to the tool cart. %>
   <% if true %>
-    <%= render 'layouts/tool_cart' %>
+    <%= render 'tool_cart/tool_cart' %>
   <% end %>
 
 

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -93,7 +93,7 @@
 
 
   <%# Change to true to enable mass-check-in. DEPRECIATED use the tool cart instead. %>
-  <% if true %>
+  <% if false %>
     <div class="panel panel-default">
       <div class="panel-heading">
         Rapid Tool Check-In

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -86,8 +86,13 @@
     <% end %>
   <% end %>
 
-  
-  <%# Change to true to enable mass-check-in %>
+  <%# Change to true to enable the quick links to the tool cart. %>
+  <% if true %>
+    <%= render 'layouts/tool_cart' %>
+  <% end %>
+
+
+  <%# Change to true to enable mass-check-in. DEPRECIATED use the tool cart instead. %>
   <% if true %>
     <div class="panel panel-default">
       <div class="panel-heading">

--- a/app/views/layouts/_tool_cart.html.erb
+++ b/app/views/layouts/_tool_cart.html.erb
@@ -1,0 +1,74 @@
+<div class="panel panel-default">
+  <div class="panel-heading">
+    Rapid Tool Management
+  </div>
+
+  <div id='tc_alert' class='panel-body' style='display: none'>
+    <span id='tc_alert_message'>The checkout was unsuccessful. Please try again at another time or ask someone for help.</span>
+  </div>
+
+  <div id='tc_scan_tools_action' class='panel-body'>
+    <%= form_tag(tool_cart_add_tool_path, method: :post, remote: true) do %>
+      <label for='tc_scan_tool'>Scan Tools</label>
+      <input id='tc_scan_tool' autocomplete="off" name="barcode" type='text' style='width: 100%' />
+    <% end %>
+    <div id='tc_tool_list_container' style='margin-bottom: 2px; <%= @tool_cart.empty? ? raw("display: none'"): ''%>'>
+      <br />
+      <div class="row">
+        <div class='col-xs-3'><strong>Barcode</strong></div>
+        <div class='col-xs-6'><strong>Name</strong></div>
+        <div class='col-xs-3'></div>
+      </div>
+      <div id="tc_tool_list" style="overflow: auto; max-height: 300px">
+        <% @tool_cart.each do |tool| %>
+          <%= render partial: 'tool_cart/tool_cart_item', locals: {tool: tool} %>
+        <% end %>
+      </div>
+    </div>
+    <br />
+    <div class="btn-group" style="width: 100%">
+      <%= button_tag 'Check Out', :class => "btn btn-default", :style => "width: 33%; white-space: normal; height: 55px",
+                     onclick: 'ToolCart.checkoutAction()'%>
+      <%= link_to 'Swap', tool_cart_swap_path, method: :post, remote: true,
+                     :class => "btn btn-default", :style => "width: 33%; white-space: normal; height: 55px; padding-top: 14px",
+                     'data-toggle' => 'tooltip', 'data-placement' => 'bottom',
+                     title: 'Scan one checked out tool and one checked in tool then hit swap to swap them!'%>
+      <%= link_to 'Check In', tool_cart_checkin_path, method: :post, remote: true,
+                  :class => "btn btn-default", :style => "width: 33%; white-space: normal; height: 55px" %>
+    </div>
+  </div>
+
+  <div id='tc_checkout_action' class="panel-body" style='display: none'>
+    <%= form_tag tool_cart_checkout_path, method: :post, remote: true, id: 'tc_checkout_form' do %>
+      <div id='tc_checkout_scan_andrewid_div'>
+        <label for='tc_checkout_scan_andrewid'>Scan Andrew ID: </label>
+        <input id='tc_checkout_scan_andrewid' autocomplete="off" type='text' style='width: 100%' />
+      </div>
+
+      <br />
+      <div id='tc_checkout_loaded_participant_div' style='display: none'>
+        <span><strong>Checkout <span id='tc_checkout_tools_count'></span> to: </strong></span><br />
+        <span id='tc_checkout_loaded_participant' style='font-weight: bold; font-size: 1.4em; color: black'>Israel Madueme</span><br />
+        <input id='tc_checkout_loaded_participant_id' name='participant_id' type='hidden' />
+
+        <br />
+        <label for='tc_checkout_select_organization'>Select Organization: </label>
+        <select id='tc_checkout_select_organization' name='organization_id' style='width: 100%'>
+        </select>
+        <div id='tc_checkout_add_membership_div' style='display: none'>
+          <span>Add Membership?</span>
+          <input id='tc_checkout_add_membership' name='add_membership' type='checkbox' />
+        </div>
+      </div>
+
+      <br />
+      <%= button_tag 'Checkout Tools', class: 'btn btn-success', style: 'width: 60%' %>
+      <%= button_tag 'Cancel', type: :button, onclick: 'ToolCart.scanToolsAction()', class: 'btn btn-default', style: 'width: 30%; float: right' %>
+      <br style='clear: both' />
+    <% end %>
+  </div>
+</div>
+
+<%= javascript_tag do %>
+  ToolCart.initSidebarWidget();
+<% end %>

--- a/app/views/layouts/_tool_cart.html.erb
+++ b/app/views/layouts/_tool_cart.html.erb
@@ -1,6 +1,6 @@
 <div class="panel panel-default">
   <div class="panel-heading">
-    Rapid Tool Management
+    Rapid Tool Management Cart
   </div>
 
   <div id='tc_alert' class='panel-body' style='display: none'>

--- a/app/views/tool_cart/_tool_cart.html.erb
+++ b/app/views/tool_cart/_tool_cart.html.erb
@@ -1,6 +1,6 @@
 <div class="panel panel-default">
   <div class="panel-heading">
-    Rapid Tool Management Cart
+    Tool Cart
   </div>
 
   <div id='tc_alert' class='panel-body' style='display: none'>
@@ -27,14 +27,12 @@
     </div>
     <br />
     <div class="btn-group" style="width: 100%">
-      <%= button_tag 'Check Out', :class => "btn btn-default", :style => "width: 33%; white-space: normal; height: 55px",
-                     onclick: 'ToolCart.checkoutAction()'%>
+      <%= button_tag 'Check Out', :class => "btn btn-primary cart-button", onclick: 'ToolCart.checkoutAction()'%>
       <%= link_to 'Swap', tool_cart_swap_path, method: :post, remote: true,
-                     :class => "btn btn-default", :style => "width: 33%; white-space: normal; height: 55px; padding-top: 14px",
+                     :class => "btn btn-primary cart-button", :style => "padding-top: 14px",
                      'data-toggle' => 'tooltip', 'data-placement' => 'bottom',
                      title: 'Scan one checked out tool and one checked in tool then hit swap to swap them!'%>
-      <%= link_to 'Check In', tool_cart_checkin_path, method: :post, remote: true,
-                  :class => "btn btn-default", :style => "width: 33%; white-space: normal; height: 55px" %>
+      <%= link_to 'Check In', tool_cart_checkin_path, method: :post, remote: true, :class => "btn btn-primary cart-button" %>
     </div>
   </div>
 

--- a/app/views/tool_cart/_tool_cart_item.html.erb
+++ b/app/views/tool_cart/_tool_cart_item.html.erb
@@ -6,13 +6,8 @@
   <div id='tool_cart_item-<%= tool.barcode %>' class='row cart-item'>
 <% end %>
   <div class='col-xs-3'><a href='/tools/<%= tool.id %>' class='btn btn-xs <%= tool.is_waitlist_critical? ? 'btn-warning':'btn-info'%>'><%= tool.barcode %></a></div>
-  <div class='col-xs-6'
-    <% if tool.is_checked_out? %>
-        data-toggle='tooltip' data-placement='bottom'
-        title='This tool is currently checked out. Checking it out will automatically check it in for the last person.'
-    <% end %>
-  >
-    <%= tool.name %><%= tool.is_checked_out? ? raw('<span>**</span>') : '' %>
+  <div class='col-xs-6'>
+    <%= tool.name %>
   </div>
   <div class='col-xs-3'><%= link_to 'Undo', tool_cart_remove_tool_path(barcode: tool.barcode), method: :post, remote: true, class: 'btn btn-danger btn-xs' %></div>
 </div>

--- a/app/views/tool_cart/_tool_cart_item.html.erb
+++ b/app/views/tool_cart/_tool_cart_item.html.erb
@@ -1,0 +1,18 @@
+<% if tool.is_waitlist_critical? %>
+  <div id='tool_cart_item-<%= tool.barcode %>'
+      class='cart-item cart-warning row' data-toggle='tooltip' data-placement='left'
+      title='There is a waitlist for type of tool and very few are checked in. Click on the barcode to see the waitlist.'>
+<% else %>
+  <div id='tool_cart_item-<%= tool.barcode %>' class='row cart-item'>
+<% end %>
+  <div class='col-xs-3'><a href='/tools/<%= tool.id %>' class='btn btn-xs <%= tool.is_waitlist_critical? ? 'btn-warning':'btn-info'%>'><%= tool.barcode %></a></div>
+  <div class='col-xs-6'
+    <% if tool.is_checked_out? %>
+        data-toggle='tooltip' data-placement='bottom'
+        title='This tool is currently checked out. Checking it out will automatically check it in for the last person.'
+    <% end %>
+  >
+    <%= tool.name %><%= tool.is_checked_out? ? raw('<span>**</span>') : '' %>
+  </div>
+  <div class='col-xs-3'><%= link_to 'Undo', tool_cart_remove_tool_path(barcode: tool.barcode), method: :post, remote: true, class: 'btn btn-danger btn-xs' %></div>
+</div>

--- a/app/views/tool_cart/add_tool.js.erb
+++ b/app/views/tool_cart/add_tool.js.erb
@@ -1,0 +1,11 @@
+(function() {
+  var $scan_tool_input = $('#tc_scan_tool'),
+      $scan_tool_list = $('#tc_tool_list'),
+      $scan_tool_list_table = $('#tc_tool_list_container');
+
+  $scan_tool_list_table.show();
+  $scan_tool_list.prepend("<%= j render partial: 'tool_cart/tool_cart_item', locals: {tool: @tool} %>");
+  $('[data-toggle="tooltip"]').tooltip();
+  $scan_tool_input.val('');
+  $scan_tool_input.focus();
+})();

--- a/app/views/tool_cart/checkin.js.erb
+++ b/app/views/tool_cart/checkin.js.erb
@@ -1,0 +1,6 @@
+(function(){
+  ToolCart.clearCartItems();
+  ToolCart.scanToolsAction();
+  ToolCart.showAlert('Successfully checked in <%= pluralize(@num_tools, 'tool') %>.',
+                      true, 4500);
+})();

--- a/app/views/tool_cart/checkout.js.erb
+++ b/app/views/tool_cart/checkout.js.erb
@@ -1,0 +1,6 @@
+(function(){
+  ToolCart.clearCartItems();
+  ToolCart.scanToolsAction();
+  ToolCart.showAlert('Successfully checked out <%= pluralize(@num_tools, 'tool') %> to <%= @person_name %> for <%= @org_name %>. All waitlists were automatically updated.',
+                      true, 4500);
+})();

--- a/app/views/tool_cart/remove_tool.js.erb
+++ b/app/views/tool_cart/remove_tool.js.erb
@@ -1,0 +1,13 @@
+(function(){
+  var $scan_tool_input = $('#tc_scan_tool'),
+      $scan_tool_list = $('#tc_tool_list');
+
+  $('[data-toggle="tooltip"]').tooltip('destroy');
+  $('#tool_cart_item-<%= barcode %>').remove();
+  $('[data-toggle="tooltip"]').tooltip();
+  $scan_tool_input.val('');
+  $scan_tool_input.focus();
+  <% if list_empty %>
+    $('#tc_tool_list_container').hide();
+  <% end %>
+})();

--- a/app/views/tool_cart/swap.js.erb
+++ b/app/views/tool_cart/swap.js.erb
@@ -1,0 +1,6 @@
+(function(){
+  ToolCart.clearCartItems();
+  ToolCart.scanToolsAction();
+  ToolCart.showAlert('Successfully swapped a <%= @old_tool_name %> for a <%= @new_tool_name %> for <%= @person_name %> in <%= @org_name %>.',
+                      true, 4500);
+})();

--- a/app/views/tool_cart/tool_cart_error.js.erb
+++ b/app/views/tool_cart/tool_cart_error.js.erb
@@ -1,0 +1,6 @@
+(function() {
+  var $scan_tool_input = $('#tc_scan_tool');
+  ToolCart.showAlert('<%= message %>', false, 3000);
+  $scan_tool_input.val('');
+  $scan_tool_input.focus();
+})();

--- a/app/views/tools/index.html.erb
+++ b/app/views/tools/index.html.erb
@@ -11,7 +11,7 @@
     <div style='float: left; border: 1px solid #ccc; border-radius: 4px; padding: 6px; margin-right: 8px;'>
       <span style='font-weight: bold; margin-right: 5px'>Filter by Tool Type</span><br />
       <select name='type_filter' class='form-control' onchange='this.form.submit()'>
-        <%= raw("<option value='' #{params[:type_filter].present? ? '':'selected'}>All tools</option>") %>
+        <%= raw("<option value='' #{params[:type_filter].present? ? '':'selected'}>All tools (except hardhats/radios)</option>") %>
         <%= raw("<option value='all_tools' #{param_equals_s(:type_filter, 'all_tools') ? 'selected':''}>All tools (Include hardhats/radios)</option>") %>
         <% ToolType.all.to_a.each do |tool_type| %>
           <%= raw("<option value='#{tool_type.id}' #{param_equals_i(:type_filter, tool_type.id) ? 'selected' : ''}>#{tool_type.name}</option>") %>

--- a/app/views/tools/index.html.erb
+++ b/app/views/tools/index.html.erb
@@ -21,7 +21,6 @@
     <div style='float: left; border: 1px solid #ccc; border-radius: 4px; padding: 6px; margin-right: 8px;'>
       <span style='font-weight: bold; margin-right: 5px'>Filter Checked Out Status </span><br />
       <select name='inventory_filter' class='form-control' onchange='this.form.submit()'>
-        <option value='' <%= @tool_type.nil? ? 'selected' : ''%> disabled>Select a tool type</option>
         <%= raw("<option value='' #{params[:inventory_filter].present? ? '':'selected'}>All</option>") %>
         <%= raw("<option value='checked_in' #{(params[:inventory_filter].present? && params[:inventory_filter] == 'checked_in') ? 'selected':''}>Checked In Only</option>") %>
         <%= raw("<option value='checked_out' #{(params[:inventory_filter].present? && params[:inventory_filter] == 'checked_out') ? 'selected':''}>Checked Out Only</option>") %>

--- a/app/views/tools/show.html.erb
+++ b/app/views/tools/show.html.erb
@@ -48,7 +48,8 @@
 <% if can?(:read, ToolWaitlist) && !@waitlist.empty? %>
   <br /><br />
   <div>
-    <h3>Waitlist for <%= @tool.tool_type.name.pluralize %></h3>
+    <h3>Waitlist for <%= link_to @tool.tool_type.name.pluralize, tools_path(type_filter: @tool.tool_type.id) %>
+      (<%= Tool.checked_in.by_type(@tool.tool_type).count %> remaining)</h3>
     <%= render partial: 'tool_waitlist' %>
   </div>
 <% end %>

--- a/app/views/tools/show.html.erb
+++ b/app/views/tools/show.html.erb
@@ -27,8 +27,8 @@
 	<% end %>
 <% else %>
   <% if can?(:create, Checkout) %>
-    <%= link_to t('.checkout', :default => t("helpers.links.checkout")),
-                    new_tool_checkout_path(@tool), :class => 'btn btn-warning' %>
+    <%= link_to 'Add to Cart', tool_cart_add_tool_path(barcode: @tool.barcode),
+                method: :post, remote: true, :class => 'btn btn-warning' %>
   <% end %>
 <% end %>
 <% if can?(:create, ToolWaitlist) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,14 @@ Trailerapp::Application.routes.draw do
   
   end
 
+  scope 'tool_cart' do
+    post 'add_tool', to: 'tool_cart#add_tool', as: :tool_cart_add_tool
+    post 'remove_tool', to: 'tool_cart#remove_tool', as: :tool_cart_remove_tool
+    post 'checkout', to: 'tool_cart#checkout', as: :tool_cart_checkout
+    post 'checkin', to: 'tool_cart#checkin', as: :tool_cart_checkin
+    post 'swap', to: 'tool_cart#swap', as: :tool_cart_swap
+  end
+
   # static pages
   get "milestones" => "home#milestones", :as => "milestones"
 


### PR DESCRIPTION
Added the tool cart feature resolving issue #151, #81, #80.

There is now a sidebar widget that allows users to easily scan a bunch of tools and choose to check them out, check them in, or swap them (if they scanned exactly 1 checked in tool and 1 checked out tool).

Checking out, checking in, and swapping can all be done through the widget and there is no need to go to another page.

I tried to test this extensively, but, this feature may have a couple bugs remaining. Please check it out and play around with it.

**Do not merge just yet as I am also going to take some time to review this PR**