### PR TITLE
Misc bug fixes and improvements

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -47,3 +47,9 @@ $(document).on("ready page:change", function(){
     }
   });
 });
+
+function _toggleText(el, opt1, opt2){
+  var $el = $(el);
+  if($el.html().trim() == opt1.trim()) $el.html(opt2);
+  else if($el.html().trim() == opt2.trim()) $el.html(opt1);
+}

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -22,7 +22,7 @@ class EventsController < ApplicationController
   def approve
     @event.is_done = !@event.is_done
     @event.save
-    respond_with @event, location: -> {events_path}
+    redirect_to :back, notice: "The note was #{@event.is_done ? 'acknowledged':'unacknowledged'}"
   end
 
   # GET /events/1/edit

--- a/app/controllers/store/purchases_controller.rb
+++ b/app/controllers/store/purchases_controller.rb
@@ -42,8 +42,6 @@ class Store::PurchasesController < ApplicationController
       c.charge_type = t
       c.description = i.store_item.name + " (x #{i.quantity_purchased})"
       c.receiving_participant_id = params[:charge][:receiving_participant_id]
-      puts(c.receiving_participant_id)
-      puts("<><><><><><<<><<><><><")
       c.issuing_participant_id = current_user.participant.id
       c.creating_participant_id = current_user.participant.id
       c.charged_at = Time.now

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -33,7 +33,7 @@ class TasksController < ApplicationController
   def complete
     @task.is_completed = true
     @task.save
-    redirect_to :back
+    redirect_to :back, notice: 'The task was successfully completed'
   end
 
   # POST /tasks

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -69,7 +69,7 @@ class Ability
       can [:create, :update], Charge
       can [:create, :update], Checkout
       can [:create, :update], Document
-      can [:create, :update], Event
+      can [:create, :update, :approve], Event
       can [:create, :update], EventType
       can [:create, :update, :destroy], Membership
       can [:hardhats, :read_basic_details, :read_all_details], Organization
@@ -79,7 +79,7 @@ class Ability
       can [:create, :update, :read_phone_number], Participant
       can :read_coord, Shift
       can :create, ShiftParticipant
-      can :update, Task
+      can [:complete, :update], Task
       can [:create, :update], Tool
       can [:create, :update], ToolType
       can [:create, :update , :destroy], ToolWaitlist

--- a/app/views/event_types/_form.html.erb
+++ b/app/views/event_types/_form.html.erb
@@ -2,8 +2,8 @@
   <%= f.error_notification %>
 
   <div class="form-inputs">
-    <%= f.input :display %>
     <%= f.input :name %>
+    <%= f.input :display,:label => "Dispaly in Sidebar?" %>
   </div>
 
   <div class="form-actions">

--- a/app/views/event_types/index.html.erb
+++ b/app/views/event_types/index.html.erb
@@ -3,8 +3,8 @@
   <table class="table">
     <thead>
       <tr>
-        <th>Display</th>
         <th>Name</th>
+        <th>Display in Sidebar</th>
         <th colspan="3"></th>
       </tr>
     </thead>
@@ -12,14 +12,16 @@
     <tbody>
       <% @event_types.each do |event_type| %>
         <tr>
-          <td><%= event_type.display %></td>
           <td><%= event_type.name %></td>
-          <% if can?(:edit, EventType) %>
-            <td><%= link_to 'Edit', edit_event_type_path(event_type),:class => 'btn btn-primary btn-xs' %></td>
-          <% end %>
-          <% if can?(:destroy, EventType) %>
-            <td><%= link_to 'Destroy', event_type, method: :delete, data: { confirm: 'Are you sure?' },:class => 'btn btn-danger btn-xs' %></td>
-          <% end %>
+          <td><%= event_type.display ? 'Yes':'No' %></td>
+          <td>
+            <% if can?(:edit, EventType) %>
+              <%= link_to 'Edit', edit_event_type_path(event_type),:class => 'btn btn-primary btn-xs' %></td>
+            <% end %>
+            <% if can?(:destroy, EventType) %>
+              <%= link_to 'Destroy', event_type, method: :delete, data: { confirm: 'Are you sure?' },:class => 'btn btn-danger btn-xs' %>
+            <% end %>
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/event_types/show.html.erb
+++ b/app/views/event_types/show.html.erb
@@ -1,10 +1,10 @@
 <h1>Event Type</h1>
 <hr/>
 <dl class="dl-horizontal">
-  <dt><strong>Display:</strong></dt>
-  <dd><%= @event_type.display %></dd>
   <dt><strong>Name:</strong></dt>
   <dd><%= @event_type.name %></dd>
+  <dt><strong>Display in Sidebar?</strong></dt>
+  <dd><%= @event_type.display ? 'Yes':'No' %></dd>
 </dl>
 
 

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -2,9 +2,22 @@
   <%= f.error_notification %>
 
   <div class="form-inputs">
-    <%= f.association :event_type %>
-    <%= f.input :description %>
-    <%= f.input :is_done%>
+    <div class='row'>
+      <div class='col-xs-12 col-sm-9'>
+        <%= f.association :event_type %>
+      </div>
+      <% if can?(:create, EventType) %>
+        <div>
+          <%= link_to "Or create a new type", new_event_type_path, class: 'btn btn-primary' %>
+        </div>
+      <% end %>
+    </div>
+    <div class='row'>
+      <div class='col-xs-12 col-sm-9'><%= f.input :description %></div>
+    </div>
+    <div class='row'>
+      <div class='col-xs-12 col-sm-9'><%= f.input :is_done%></div>
+    </div>
   </div>
 
   <div class="form-actions">

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -7,13 +7,13 @@
         <th>Event Type</th>
         <th>Description</th>
         <th>Created</th>
-        <th colspan="3"></th>
+        <th></th>
       </tr>
     </thead>
   
     <tbody>
       <% @events.each do |event| %>
-        <tr <%= raw('class="warning"') if !event.is_done %>>
+        <tr <%= raw('class="warning"') unless event.is_done %>>
           <td><%= link_to 'Show', event, :class => 'btn btn-info btn-xs' %></td>
           <td><%= event.event_type.name %></td>
           <td><%= event.description %></td>
@@ -28,9 +28,9 @@
                   <% end %>
               <% end %>
             <% end %>
+            <%= link_to 'Edit', edit_event_path(event),:class => 'btn btn-primary btn-xs' %>
+            <%= link_to 'Destroy', event, method: :delete, data: { confirm: 'Are you sure?' },:class => 'btn btn-danger btn-xs' %>
           </td>
-            <td><%= link_to 'Edit', edit_event_path(event),:class => 'btn btn-primary btn-xs' %></td>
-            <td><%= link_to 'Destroy', event, method: :delete, data: { confirm: 'Are you sure?' },:class => 'btn btn-danger btn-xs' %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -2,9 +2,15 @@
   <% cache ['shift_sidebar', 'current', @current_shifts_sidebar, 'upcoming', @upcoming_shifts_sidebar] do%>
     <div class="panel panel-default">
       <div class="panel-heading">
-        Shifts
+        <div class='row'>
+          <div class='col-xs-9'>Shifts</div>
+          <div class='col-xs-3'>
+            <a href="#sidebar-shifts-widget" onclick='_toggleText(this, "Show", "Hide")'
+               class="btn btn-info btn-xs"  data-toggle="collapse">Hide</a>
+          </div>
+        </div>
       </div>
-      <div class="panel-body">
+      <div id='sidebar-shifts-widget' class="collapse in panel-body">
         <table class="table table-condensed" style="margin-bottom: 0;">
           <thead>
             <th>Current</th>
@@ -19,6 +25,7 @@
                       <%= link_to shift.shift_participants.first.participant.name, shift unless shift.shift_participants.blank? %>
                     <% else %>
                       <%= link_to shift.organization.short_name, shift unless shift.organization.blank? %>
+                      <%= link_to 'No Org Assigned', shift if shift.organization.blank? %>
                     <% end %>
                   </td>
                   <td style="text-align: right;"><%= time shift.ends_at %></td>
@@ -59,9 +66,15 @@
     <% cache ['tasks_sidebar', @tasks_sidebar] do %>
       <div class="panel panel-default">
         <div class="panel-heading">
-          Events/Tasks
+          <div class='row'>
+          <div class='col-xs-9'>Events/Tasks</div>
+          <div class='col-xs-3'>
+            <a href="#sidebar-tasks-widget" onclick='_toggleText(this, "Show", "Hide")'
+               class="btn btn-info btn-xs"  data-toggle="collapse">Hide</a>
+          </div>
         </div>
-        <div class="panel-body">
+        </div>
+        <div id='sidebar-tasks-widget' class="collapse in panel-body">
           <table class="table table-condensed" style="margin-bottom: 0;">
             <thead>
               <th>Title</th>
@@ -70,7 +83,7 @@
             </thead>
             <tbody>
               <% @tasks_sidebar.each do |task| %>
-                <tr class="sidebar-tooltip" data-toggle="tooltip" data-placement="left" title="<%=h task.name %>:</br></br><%=h task.description %>">
+                <tr class="sidebar-tooltip" data-toggle="tooltip" data-placement="left" title="<%=h task.name %>: <%=h task.description %>">
                   <td style="max-width: 103px; white-space: nowrap; text-overflow: ellipsis; overflow: hidden;"><%=h task.name %></td>
                   <td style="text-align: right;"><%= time task.due_at%></td>
                   <% if can?(:update, task) %>
@@ -96,9 +109,15 @@
   <% if false %>
     <div class="panel panel-default">
       <div class="panel-heading">
-        Rapid Tool Check-In
+        <div class='row'>
+          <div class='col-xs-9'>Rapid Tool Check-In</div>
+          <div class='col-xs-3'>
+            <a href="#sidebar-rapidtoolcheckin-widget" onclick='_toggleText(this, "Show", "Hide")'
+               class="btn btn-info btn-xs"  data-toggle="collapse">Hide</a>
+          </div>
+        </div>
       </div>
-      <div class="panel-body">
+      <div id='sidebar-rapidtoolcheckin-widget' class="collapse in panel-body">
         <h5>For Organization:</h5>
         <%= simple_form_for Checkout.new, url: checkin_checkouts_path, remote: true do |f| %>
           <%= f.input_field :organization_id, :as => :select, :collection => Organization.all %>
@@ -135,9 +154,15 @@
   <% if true %>
     <div class="panel panel-default">
       <div class="panel-heading">
-        Downtime
+        <div class='row'>
+          <div class='col-xs-9'>Downtime</div>
+          <div class='col-xs-3'>
+            <a href="#sidebar-downtime-widget" onclick='_toggleText(this, "Show", "Hide")'
+               class="btn btn-info btn-xs"  data-toggle="collapse">Hide</a>
+          </div>
+        </div>
       </div>
-      <div class="panel-body">
+      <div id='sidebar-downtime-widget' class="collapse in panel-body">
         <table class="table table-condensed">
           <thead>
             <th style="text-align: center;">Org</th>
@@ -171,9 +196,15 @@
   <% if true %>
     <div class="panel panel-default">
       <div class="panel-heading">
-        Queues
+        <div class='row'>
+          <div class='col-xs-9'>Queues</div>
+          <div class='col-xs-3'>
+            <a href="#sidebar-queues-widget" onclick='_toggleText(this, "Show", "Hide")'
+               class="btn btn-info btn-xs"  data-toggle="collapse">Hide</a>
+          </div>
+        </div>
       </div>
-      <div class="panel-body">
+      <div id='sidebar-queues-widget' class="collapse in panel-body">
         <table class="table table-condensed" style="width: 50%; float: left; border-right: 1px solid #dddddd;">
           <thead>
             <th style="text-align: center;">Structural</th>
@@ -219,9 +250,15 @@
   <% if true %>
     <div class="panel panel-default">
       <div class="panel-heading">
-        Notes
+        <div class='row'>
+          <div class='col-xs-9'>Notes</div>
+          <div class='col-xs-3'>
+            <a href="#sidebar-events-widget" onclick='_toggleText(this, "Show", "Hide")'
+               class="btn btn-info btn-xs"  data-toggle="collapse">Hide</a>
+          </div>
+        </div>
       </div>
-      <div class="panel-body">
+      <div id='sidebar-events-widget' class="collapse in panel-body">
         <table class="table table-condensed">
           <thead>
             <th style="text-align: center">Note</th>
@@ -242,6 +279,7 @@
             <% end %>
           </tbody>
         </table>
+        <%= link_to 'Create a new note', new_event_path, class: 'btn btn-xs btn-primary' %>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
- Ability to collapse sidebar widgets (except the Tool Cart due to it's complexity). Note that this does not persist across page refreshs. That will be another issue to work on.

- Removed unnessacry debug statements in the StorePurchasesController

- Gave SCC members the ability to complete Tasks

- Gave SCC members the ability to acknolege event log notes.

- Slightly improved the CRUD views for Events and Event Types. This also includes adding a button to create a new Event Type on the New Event form page.

- Fixed a bug where there would be no link to a shift in the sidebar widget if there was no org assigned to it (thus making it difficult for anyone to find the shift). Now shows the link to shift with no organization assigned using the title "No Org Assigned".

- Removed unnessacry `<br />` tags in the task sidebar tool tips. They were being displayed as text tooltips only accept text.