### PR TITLE
Reorganized top level navigation and separated sidebar into partials

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -327,5 +327,8 @@ DEPENDENCIES
   will_paginate
   will_paginate-bootstrap
 
+RUBY VERSION
+   ruby 2.1.5p273
+
 BUNDLED WITH
-   1.11.2
+   1.12.0.rc

--- a/app/controllers/event_types_controller.rb
+++ b/app/controllers/event_types_controller.rb
@@ -29,7 +29,13 @@ class EventTypesController < ApplicationController
 
     respond_to do |format|
       if @event_type.save
-        format.html { redirect_to @event_type, notice: 'Event type was successfully created.' }
+        format.html {
+          if params[:from_new_event].present?
+            redirect_to new_event_path, notice: 'Event type was successfully created.'
+            return
+          end
+          redirect_to @event_type, notice: 'Event type was successfully created.'
+        }
         format.json { render :show, status: :created, location: @event_type }
       else
         format.html { render :new }

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -36,6 +36,8 @@ class Ability
 
     can :create, Membership, :participant_id => user.participant.id
 
+    can :read, StoreItem
+
     if user.participant.is_booth_chair?
       can :read, [ChargeType, Checkout, Shift]
       can :read_basic_details, Organization
@@ -79,6 +81,7 @@ class Ability
       can [:create, :update, :read_phone_number], Participant
       can :read_coord, Shift
       can :create, ShiftParticipant
+      can [:create, :update], StoreItem
       can [:complete, :update], Task
       can [:create, :update], Tool
       can [:create, :update], ToolType

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -25,7 +25,7 @@ class Task < ActiveRecord::Base
 
   default_scope { order('due_at ASC') }
   scope :upcoming, lambda{ where("due_at < ?", DateTime.now + 4.hour) }
-  scope :is_incomplete, lambda{ where(is_completed: false)}
+  scope :is_incomplete, lambda{ where('is_completed = FALSE OR is_completed IS NULL')}
   scope :is_complete, lambda{ where(is_completed: true)}
   def is_past_due
     return self.due_at < Time.now

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -25,7 +25,7 @@ class Task < ActiveRecord::Base
 
   default_scope { order('due_at ASC') }
   scope :upcoming, lambda{ where("due_at < ?", DateTime.now + 4.hour) }
-  scope :is_incomplete, lambda{ where('is_completed = FALSE OR is_completed IS NULL')}
+  scope :is_incomplete, lambda{ where(is_completed: [false, nil])}
   scope :is_complete, lambda{ where(is_completed: true)}
   def is_past_due
     return self.due_at < Time.now

--- a/app/views/event_types/_form.html.erb
+++ b/app/views/event_types/_form.html.erb
@@ -1,9 +1,11 @@
 <%= simple_form_for @event_type, :html => { :class => 'form-horizontal' } do |f| %>
   <%= f.error_notification %>
+  <%= hidden_field(nil, :from_new_event, :value => params[:from_new_event]) %>
 
   <div class="form-inputs">
     <%= f.input :name %>
     <%= f.input :display,:label => "Dispaly in Sidebar?" %>
+
   </div>
 
   <div class="form-actions">

--- a/app/views/events/_events_sidebar.html.erb
+++ b/app/views/events/_events_sidebar.html.erb
@@ -1,0 +1,34 @@
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <div class='row'>
+      <div class='col-xs-9'>Notes</div>
+      <div class='col-xs-3'>
+        <a href="#sidebar-events-widget" onclick='_toggleText(this, "Show", "Hide")'
+           class="btn btn-info btn-xs"  data-toggle="collapse">Hide</a>
+      </div>
+    </div>
+  </div>
+  <div id='sidebar-events-widget' class="collapse panel-body">
+    <table class="table table-condensed">
+      <thead>
+        <th>Note</th>
+        <th style="text-align: center">Actions</th>
+      </thead>
+      <tbody>
+        <% @events_sidebar.each do |event| %>
+            <tr>
+              <td style="text-align: center;"><%= link_to event.description.truncate(150), event_path(event) %></td>
+              <td>              
+                <%= form_tag approve_event_path(event), method: :put %>
+                  <%= hidden_field_tag 'url', request.original_fullpath %>
+                  <% unless event.is_done %>
+                    <%= submit_tag 'OK', :class => 'btn btn-success btn-xs' %>
+                  <% end %>
+            </td>
+            </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <%= link_to 'Create a new note', new_event_path, class: 'btn btn-primary', :style => "width: 100%" %>
+  </div>
+</div>

--- a/app/views/events/_events_sidebar.html.erb
+++ b/app/views/events/_events_sidebar.html.erb
@@ -4,7 +4,7 @@
       <div class='col-xs-9'>Notes</div>
       <div class='col-xs-3'>
         <a href="#sidebar-events-widget" onclick='_toggleText(this, "Show", "Hide")'
-           class="btn btn-info btn-xs"  data-toggle="collapse">Hide</a>
+           class="btn btn-info btn-xs"  data-toggle="collapse">Show</a>
       </div>
     </div>
   </div>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -8,7 +8,7 @@
       </div>
       <% if can?(:create, EventType) %>
         <div>
-          <%= link_to "Or create a new type", new_event_type_path, class: 'btn btn-primary' %>
+          <%= link_to "Or create a new type", new_event_type_path(from_new_event: true), class: 'btn btn-primary' %>
         </div>
       <% end %>
     </div>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -15,9 +15,6 @@
     <div class='row'>
       <div class='col-xs-12 col-sm-9'><%= f.input :description %></div>
     </div>
-    <div class='row'>
-      <div class='col-xs-12 col-sm-9'><%= f.input :is_done%></div>
-    </div>
   </div>
 
   <div class="form-actions">

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -18,7 +18,7 @@
   </div>
 
   <div class="form-actions">
-    <%= f.button :submit, :class => 'btn-primary' %>
+    <%= f.button :submit, 'Create Note', :class => 'btn-primary' %>
     <%= link_to t('.cancel', :default => t("helpers.links.cancel")),
                 @event, :class => 'btn btn-default' %>
   </div>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,5 +1,5 @@
   <div class="page-header">
-      <h1> New Event </h1>
+      <h1> New Note </h1>
   </div>
     
   <%= render 'form' %>

--- a/app/views/home/_quick_links.html.erb
+++ b/app/views/home/_quick_links.html.erb
@@ -1,32 +1,33 @@
 <div class="page-header">
-  <h1>Quick Links:</h1>
+  <h1>Binder</h1>
 </div>	
 
 <div class="col-xs-10 col-sm-6">
-  <p><%= link_to "Milestones", milestones_path, :class => "btn btn-primary" %></p>
-  <p><%= link_to "Documents", documents_path, :class => "btn btn-primary" %></p>
-  <% if can?(:read, Faq) %>
-    <p><%= link_to "Frequently Asked Questions", faqs_path, :class => "btn btn-primary " %></p>
+  <% if user_signed_in? and !current_user.participant.has_signed_waiver? then %>
+    <p><%= link_to "Sign Waiver", new_waiver_path, :class => "btn btn-success" %></p>
+    <br>
   <% end %>
-  <% if defined? user then %>
-    <p><%= link_to "Sign Waiver", new_waiver_path, :class => "btn btn-primary" %></p>
+
+  <% if can?(:read, Charge) %>
+    <p><%= link_to "Charges", charges_path, :class => "btn btn-primary" %></p>
+  <% end %>
+  <% if can?(:read, Document) %>
+    <p><%= link_to "Documents", documents_path, :class => "btn btn-primary" %></p>
   <% end %>
   <% if can?(:downtime, OrganizationTimelineEntry) %>
-    <p><%= link_to "Downtime Tracker", downtime_index_path	, :class => "btn btn-primary" %></p>
+    <p><%= link_to "Downtime", downtime_index_path, :class => "btn btn-primary" %></p>
   <% end %>
-  <% if can?(:structural, OrganizationTimelineEntry) %>
-    <p><%= link_to "Structural Queue", structural_path, :class => "btn btn-primary " %></p>
+  <% if can?(:read, Faq) %>
+    <p><%= link_to "FAQs", faqs_path, :class => "btn btn-primary" %></p>
   <% end %>
-  <% if can?(:electrical, OrganizationTimelineEntry) %>
-    <p><%= link_to "Electrical Queue", electrical_path, :class => "btn btn-primary " %></p>
+  <% if can?(:read, Shift) %>
+    <p><%= link_to "Shifts", shifts_path, :class => "btn btn-primary" %></p>
   <% end %>
-  <% if can?(:read, Event) %>
-    <p><%= link_to "Events", events_path, :class => "btn btn-primary " %></p>
+  <% if can?(:read, Task) %>
+    <p><%= link_to "Tasks", tasks_path, :class => "btn btn-primary" %></p>
   <% end %>
-  <% if can?(:approve, Charge) %>
-        <p><%= link_to "Charge Overview", charge_overview_path, :class => "btn btn-primary " %></p>
-        <p><%= link_to "Store", store_items_path, :class => "btn btn-primary " %></p>
-  <% end %>
+
+  <br>
 
   <%= form_tag(search_path, class: 'form-inline', role: 'search') do %>
     <div class="form-group">

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -22,28 +22,50 @@
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">Other Links<b class="caret"></b></a>
             <ul class="dropdown-menu">
-              <li><%= link_to "Participants", participants_path %></li>
               <% if can?(:read, Charge) %>
                 <li><%= link_to "Charges", charges_path %></li>
+              <% end %>
+              <% if can?(:read, Document) %>
+                <li><%= link_to "Documents", documents_path %></li>
+              <% end %>
+              <% if can?(:read, Faq) %>
+                <li><%= link_to "FAQs", faqs_path %></li>
+              <% end %>
+              <% if can?(:read, Participant) %>
+                <li><%= link_to "Participants", participants_path %></li>
+              <% end %>
+              <% if can?(:read, Shift) %>
+                <li><%= link_to "Shifts", shifts_path(:type => "watch") %></li>
               <% end %>
               <% if can?(:read, Task) %>
                 <li><%= link_to "Tasks", tasks_path %></li>
               <% end %>
-              <li><%= link_to "Shifts", shifts_path(:type => "watch") %></li>
-              <li><%= link_to "Documents", documents_path %></li>
-              <% if can?(:read, Faq) %>
-                <li><%= link_to "FAQs", faqs_path %></li>
-              <% end %>
-              <li><%= link_to "Milestones", milestones_path %></li>
-              <li><%= link_to "Sign Waiver", new_waiver_path %></li>
-              <% if can?(:read, ToolType) %>
-                <li><%= link_to "Tool Types", tool_types_path %></li>
-              <% end %>
-              <% if can?(:create, :reports) %>
-                <li><%= link_to "Reports", reports_path %></li>
-              <% end %>
             </ul>
           </li>
+
+          <% if current_user.participant.is_scc? %>
+            <li class="dropdown">
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown">SCC Links<b class="caret"></b></a>
+              <ul class="dropdown-menu">
+                <% if can?(:downtime, OrganizationTimelineEntry) %>
+                  <li><%= link_to "Downtime", downtime_index_path %></li>
+                <% end %>
+                <% if can?(:structural, OrganizationTimelineEntry) %>
+                  <li><%= link_to "Structural Queue", structural_path %></li>
+                <% end %>
+                <% if can?(:electrical, OrganizationTimelineEntry) %>
+                  <li><%= link_to "Electrical Queue", electrical_path %></li>
+                <% end %>
+                <% if can?(:read, Event) %>
+                  <li><%= link_to "Event Log", events_path %></li>
+                <% end %>
+                <% if can?(:create, :reports) %>
+                  <li><%= link_to "Reports", reports_path %></li>
+                <% end %>
+              </ul>
+            </li>
+          <% end %>
+
         </ul>
         <!-- Searchbar -->
         <form class="navbar-form navbar-left" role="search" accept-charset="UTF-8" action="/search" method="get" >
@@ -58,6 +80,9 @@
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown"><%= Rails.env.production? ? current_user.participant.name : session[:name] %><b class="caret"></b></a>
             <ul class="dropdown-menu">
+              <% if !current_user.participant.has_signed_waiver %>
+                <li><%= link_to "Sign Waiver", new_waiver_path %></li>
+              <% end %>
               <li>
                 <%= link_to 'Logout', destroy_user_session_path, :id => 'log_out' %>
               </li>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -1,289 +1,32 @@
+<% if current_user.participant.is_scc? %>
+  <%= render 'tool_cart/tool_cart' %>
+
+  <% if !@tasks_sidebar.blank? %>
+    <% cache ['tasks_sidebar', @tasks_sidebar] do %>
+      <%= render 'tasks/tasks_sidebar' %>
+    <% end %>
+  <% end %>
+<% end %>
+
 <% if !@current_shifts_sidebar.blank? or !@upcoming_shifts_sidebar.blank? %>
   <% cache ['shift_sidebar', 'current', @current_shifts_sidebar, 'upcoming', @upcoming_shifts_sidebar] do%>
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        <div class='row'>
-          <div class='col-xs-9'>Shifts</div>
-          <div class='col-xs-3'>
-            <a href="#sidebar-shifts-widget" onclick='_toggleText(this, "Show", "Hide")'
-               class="btn btn-info btn-xs"  data-toggle="collapse">Hide</a>
-          </div>
-        </div>
-      </div>
-      <div id='sidebar-shifts-widget' class="collapse in panel-body">
-        <table class="table table-condensed" style="margin-bottom: 0;">
-          <thead>
-            <th>Current</th>
-            <th style="text-align: right;">Ends at</th>
-          </thead>
-          <tbody>
-            <% cache ['current_sidebar', @current_shifts_sidebar] do %>
-              <% @current_shifts_sidebar.each do |shift| %>
-                <tr class="sidebar-tooltip <%= shift.is_checked_in ? 'success' : 'danger' %>" id="" data-toggle="tooltip" data-placement="left" title="<%= shift.shift_type.name %><%=h ' - ' + shift.description + ' (' + shift.required_number_of_participants.to_s + ')'  unless shift.description.blank? %>">
-                  <td style="max-width: 103px; white-space: nowrap; text-overflow: ellipsis; overflow: hidden;">
-                    <% if (shift.shift_type.name == "Coordinator Shift") %>
-                      <%= link_to shift.shift_participants.first.participant.name, shift unless shift.shift_participants.blank? %>
-                    <% else %>
-                      <%= link_to shift.organization.short_name, shift unless shift.organization.blank? %>
-                      <%= link_to 'No Org Assigned', shift if shift.organization.blank? %>
-                    <% end %>
-                  </td>
-                  <td style="text-align: right;"><%= time shift.ends_at %></td>
-                </tr>
-              <% end %>
-            <% end %>
-          </tbody>
-        </table>
-        <table class="table table-condensed table-striped" style="margin-bottom: 0;">
-          <thead>
-            <th>Upcoming</th>
-            <th style="text-align: right;">Starts at</th>
-          </thead>
-          <tbody>
-            <% cache ['upcoming_sidebar', @upcoming_shifts_sidebar] do %>
-              <% @upcoming_shifts_sidebar.each do |shift| %>
-                <tr class="sidebar-tooltip <%= shift.is_checked_in ? 'success' : 'warning' %>" id="" data-toggle="tooltip" data-placement="left" title="<%= shift.shift_type.name %><%=h ' - ' + shift.description + ' (' + shift.required_number_of_participants.to_s + ')'  unless shift.description.blank? %>">
-                  <td style="max-width: 103px; white-space: nowrap; text-overflow: ellipsis; overflow: hidden;">
-                    <% if (shift.shift_type.name == "Coordinator Shift") %>
-                      <%= link_to shift.shift_participants.first.participant.name, shift unless shift.shift_participants.blank? %>
-                    <% else %>
-                      <%= link_to shift.organization.short_name, shift unless shift.organization.blank? %>
-                     <% end %>
-                  </td>
-                  <td style="text-align: right;"><%= time shift.starts_at %></td>
-                </tr>
-              <% end %>
-            <% end %>
-          </tbody>
-        </table>
-      </div>
-    </div>
+      <%= render 'shifts/shifts_sidebar' %>
   <% end %>
 <% end %>
 
 <% if current_user.participant.is_scc? %>
-  <% if !@tasks_sidebar.blank? %>
-    <% cache ['tasks_sidebar', @tasks_sidebar] do %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <div class='row'>
-          <div class='col-xs-9'>Events/Tasks</div>
-          <div class='col-xs-3'>
-            <a href="#sidebar-tasks-widget" onclick='_toggleText(this, "Show", "Hide")'
-               class="btn btn-info btn-xs"  data-toggle="collapse">Hide</a>
-          </div>
-        </div>
-        </div>
-        <div id='sidebar-tasks-widget' class="collapse in panel-body">
-          <table class="table table-condensed" style="margin-bottom: 0;">
-            <thead>
-              <th>Title</th>
-              <th style="text-align: right;">Due By</th>
-              <th style="text-align: center;">Action</th>
-            </thead>
-            <tbody>
-              <% @tasks_sidebar.each do |task| %>
-                <tr class="sidebar-tooltip" data-toggle="tooltip" data-placement="left" title="<%=h task.name %>: <%=h task.description %>">
-                  <td style="max-width: 103px; white-space: nowrap; text-overflow: ellipsis; overflow: hidden;"><%=h task.name %></td>
-                  <td style="text-align: right;"><%= time task.due_at%></td>
-                  <% if can?(:update, task) %>
-                    <td style="text-align: center;"><%= link_to t('.complete', :default => t("helpers.links.complete")),
-                        complete_task_path(task), :method => :post, :class => 'btn btn-xs btn-success' %></td>
-                  <% end %>
-                </tr>
-              <% end %>
-            </tbody>
-          </table>
-        </div>
-      </div>
-    <% end %>
-  <% end %>
-
-  <%# Change to true to enable the quick links to the tool cart. %>
-  <% if true %>
-    <%= render 'tool_cart/tool_cart' %>
-  <% end %>
-
-
-  <%# Change to true to enable mass-check-in. DEPRECIATED use the tool cart instead. %>
-  <% if false %>
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        <div class='row'>
-          <div class='col-xs-9'>Rapid Tool Check-In</div>
-          <div class='col-xs-3'>
-            <a href="#sidebar-rapidtoolcheckin-widget" onclick='_toggleText(this, "Show", "Hide")'
-               class="btn btn-info btn-xs"  data-toggle="collapse">Hide</a>
-          </div>
-        </div>
-      </div>
-      <div id='sidebar-rapidtoolcheckin-widget' class="collapse in panel-body">
-        <h5>For Organization:</h5>
-        <%= simple_form_for Checkout.new, url: checkin_checkouts_path, remote: true do |f| %>
-          <%= f.input_field :organization_id, :as => :select, :collection => Organization.all %>
-          <div style="width: 100%; height: 5px; clear: both;"></div>
-          <%= text_field_tag :barcode, '', style: "width: 100%;"  %>
-          <div style="width: 100%; height: 5px; clear: both;"></div>
-          <%= hidden_field_tag 'url', request.original_fullpath %>
-          <div style="width: 100%; height: 10px; clear: both;"></div>
-          <%= f.submit 'Check-In', :class => "btn btn-primary", :style => "width: 100%" %>
-        <% end %>
-          
-        <div style="width: 100%; height: 20px; clear: both;"></div>
-        <div style="width: 100%; height: 0px; clear: both; border-top: 1px solid #dddddd;"></div>
-        <div style="width: 100%; height: 10px; clear: both;"></div>
-        
-        
-        <table class="table table-condensed" id="rapid-checkin-sidebar">
-          <thead>
-            <th style="text-align: center;">Org</th>
-            <th style="text-align: right;">Barcode</th>
-            <th></th>
-          </thead>
-          <tbody>
-            
-          </tbody>
-        </table>
-
-
-      </div>
-    </div>
-    <% end %>
-    
-  <%# Change to true to enable downtime %>
-  <% if true %>
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        <div class='row'>
-          <div class='col-xs-9'>Downtime</div>
-          <div class='col-xs-3'>
-            <a href="#sidebar-downtime-widget" onclick='_toggleText(this, "Show", "Hide")'
-               class="btn btn-info btn-xs"  data-toggle="collapse">Hide</a>
-          </div>
-        </div>
-      </div>
-      <div id='sidebar-downtime-widget' class="collapse in panel-body">
-        <table class="table table-condensed">
-          <thead>
-            <th style="text-align: center;">Org</th>
-            <th style="text-align: right;">Left</th>
-            <th></th>
-          </thead>
-          <tbody>
-            <% @downtime_sidebar.each do |entry| %>
-              <tr <%= raw('class="danger"') if entry.organization.remaining_downtime < 0 %>>
-                <td style="text-align: center;"><%= link_to entry.organization.short_name, organization_downtime_index_path(entry.organization) %></td>
-                <td style="text-align: right;"><span id="countdown"><%= format_remaining_downtime entry.organization.remaining_downtime %></span></td>
-                <td><%= form_tag end_organization_timeline_entry_path(entry), method: :put do %><%= hidden_field_tag 'url', request.original_fullpath %><%= submit_tag 'Stop', class: 'btn btn-xs btn-danger' %><% end %></td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
-        <div style="width: 100%; height: 0px; clear: both; border-top: 1px solid #dddddd;"></div>
-        <h5>Start Downtime:</h5>
-        <%= simple_form_for OrganizationTimelineEntry.new do |f| %>
-          <%= f.input_field :organization_id, :as => :select, :collection => Organization.all %>
-          <div style="width: 100%; height: 5px; clear: both;"></div>
-          <%= hidden_field_tag 'url', request.original_fullpath %>
-          <div style="width: 100%; height: 10px; clear: both;"></div>
-          <%= f.submit 'Downtime', :class => "btn btn-primary", :style => "width: 100%" %>
-        <% end %>
-      </div>
-    </div>
-  <% end %>
-
   <%# Change to true to enable queues %>
   <% if true %>
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        <div class='row'>
-          <div class='col-xs-9'>Queues</div>
-          <div class='col-xs-3'>
-            <a href="#sidebar-queues-widget" onclick='_toggleText(this, "Show", "Hide")'
-               class="btn btn-info btn-xs"  data-toggle="collapse">Hide</a>
-          </div>
-        </div>
-      </div>
-      <div id='sidebar-queues-widget' class="collapse in panel-body">
-        <table class="table table-condensed" style="width: 50%; float: left; border-right: 1px solid #dddddd;">
-          <thead>
-            <th style="text-align: center;">Structural</th>
-          </thead>
-          <tbody>
-            <% @structural_queue_sidebar.each do |entry| %>
-              <tr class="sidebar-popover" data-toggle="popover" data-placement="left" title="Entered at <%= date_and_time entry.started_at %>" data-content='<%=h entry.description %></br><%= form_tag end_organization_timeline_entry_path(entry), method: :put do %><%= hidden_field_tag 'url', request.original_fullpath %><%= submit_tag 'Remove', class: 'btn btn-xs btn-danger' %><% end %>'>
-                <td style="text-align: center;"><%= entry.organization.short_name %></td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
-        <table class="table table-condensed" style="width: 50%; border-left: 1px solid #dddddd;">
-          <thead>
-            <th style="text-align: center;">Electrical</th>
-          </thead>
-          <tbody>
-            <% @electrical_queue_sidebar.each do |entry| %>
-              <tr class="sidebar-popover" data-toggle="popover" data-placement="left" title="Entered at <%= date_and_time entry.started_at %>" data-content='<%=h entry.description %></br><%= form_tag end_organization_timeline_entry_path(entry), method: :put do %><%= hidden_field_tag 'url', request.original_fullpath %><%= submit_tag 'Remove', class: 'btn btn-xs btn-danger' %><% end %>'>
-                <td style="text-align: center;"><%= entry.organization.short_name %></td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
-        <div style="width: 100%; height: 0px; clear: both; border-top: 1px solid #dddddd;"></div>
-        <h5>Add to Queue:</h5>
-        <%= simple_form_for OrganizationTimelineEntry.new do |f| %>
-          <%= f.input_field :organization_id, :as => :select, :collection => Organization.all %>
-          <div style="width: 100%; height: 5px; clear: both;"></div>
-          <%= f.input_field :description, :as => :string %>
-          <%= hidden_field_tag 'url', request.original_fullpath %>
-          <div style="width: 100%; height: 10px; clear: both;"></div>
-          <div class="btn-group" style="width: 100%;">
-            <%= f.submit 'Structural', :class => "btn btn-default", :style => "width: 50%;" %>
-            <%= f.submit 'Electrical', :class => "btn btn-default", :style => "width: 50%;" %>
-          </div>
-        <% end %>
-      </div>
-    </div>
+    <%= render 'organization_timeline_entries/queue_sidebar' %>    
   <% end %>
-
-<%# Change to true to enable event sidebar %>
+  
+  <%# Change to true to enable downtime %>
   <% if true %>
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        <div class='row'>
-          <div class='col-xs-9'>Notes</div>
-          <div class='col-xs-3'>
-            <a href="#sidebar-events-widget" onclick='_toggleText(this, "Show", "Hide")'
-               class="btn btn-info btn-xs"  data-toggle="collapse">Hide</a>
-          </div>
-        </div>
-      </div>
-      <div id='sidebar-events-widget' class="collapse in panel-body">
-        <table class="table table-condensed">
-          <thead>
-            <th style="text-align: center">Note</th>
-            <th>Actions</th>
-          </thead>
-          <tbody>
-            <% @events_sidebar.each do |event| %>
-                <tr>
-                  <td style="text-align: center;"><%= link_to event.description.truncate(150), event_path(event) %></td>
-                  <td>              
-                    <%= form_tag approve_event_path(event), method: :put %>
-                      <%= hidden_field_tag 'url', request.original_fullpath %>
-                      <% unless event.is_done %>
-                        <%= submit_tag 'OK', :class => 'btn btn-success btn-xs' %>
-                      <% end %>
-                </td>
-                </tr>
-            <% end %>
-          </tbody>
-        </table>
-        <%= link_to 'Create a new note', new_event_path, class: 'btn btn-xs btn-primary' %>
-      </div>
-    </div>
+    <%= render 'organization_timeline_entries/downtime_sidebar' %>
   <% end %>
 
-
+  <%# Change to true to enable event sidebar %>
+  <% if true %>
+    <%= render 'events/events_sidebar' %>
+  <% end %>
 <% end %>
-

--- a/app/views/organization_timeline_entries/_downtime_sidebar.html.erb
+++ b/app/views/organization_timeline_entries/_downtime_sidebar.html.erb
@@ -1,0 +1,38 @@
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <div class='row'>
+      <div class='col-xs-9'>Downtime</div>
+      <div class='col-xs-3'>
+        <a href="#sidebar-downtime-widget" onclick='_toggleText(this, "Show", "Hide")'
+           class="btn btn-info btn-xs"  data-toggle="collapse">Hide</a>
+      </div>
+    </div>
+  </div>
+  <div id='sidebar-downtime-widget' class="collapse panel-body">
+    <table class="table table-condensed">
+      <thead>
+        <th style="text-align: center;">Org</th>
+        <th style="text-align: right;">Left</th>
+        <th></th>
+      </thead>
+      <tbody>
+        <% @downtime_sidebar.each do |entry| %>
+          <tr <%= raw('class="danger"') if entry.organization.remaining_downtime < 0 %>>
+            <td style="text-align: center;"><%= link_to entry.organization.short_name, organization_downtime_index_path(entry.organization) %></td>
+            <td style="text-align: right;"><span id="countdown"><%= format_remaining_downtime entry.organization.remaining_downtime %></span></td>
+            <td><%= form_tag end_organization_timeline_entry_path(entry), method: :put do %><%= hidden_field_tag 'url', request.original_fullpath %><%= submit_tag 'Stop', class: 'btn btn-xs btn-danger' %><% end %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <div style="width: 100%; height: 0px; clear: both; border-top: 1px solid #dddddd;"></div>
+    <h5>Start Downtime:</h5>
+    <%= simple_form_for OrganizationTimelineEntry.new do |f| %>
+      <%= f.input_field :organization_id, :as => :select, :collection => Organization.all %>
+      <div style="width: 100%; height: 5px; clear: both;"></div>
+      <%= hidden_field_tag 'url', request.original_fullpath %>
+      <div style="width: 100%; height: 10px; clear: both;"></div>
+      <%= f.submit 'Downtime', :class => "btn btn-primary", :style => "width: 100%" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/organization_timeline_entries/_downtime_sidebar.html.erb
+++ b/app/views/organization_timeline_entries/_downtime_sidebar.html.erb
@@ -4,7 +4,7 @@
       <div class='col-xs-9'>Downtime</div>
       <div class='col-xs-3'>
         <a href="#sidebar-downtime-widget" onclick='_toggleText(this, "Show", "Hide")'
-           class="btn btn-info btn-xs"  data-toggle="collapse">Hide</a>
+           class="btn btn-info btn-xs"  data-toggle="collapse">Show</a>
       </div>
     </div>
   </div>

--- a/app/views/organization_timeline_entries/_queue_sidebar.html.erb
+++ b/app/views/organization_timeline_entries/_queue_sidebar.html.erb
@@ -4,7 +4,7 @@
       <div class='col-xs-9'>Queues</div>
       <div class='col-xs-3'>
         <a href="#sidebar-queues-widget" onclick='_toggleText(this, "Show", "Hide")'
-           class="btn btn-info btn-xs"  data-toggle="collapse">Hide</a>
+           class="btn btn-info btn-xs"  data-toggle="collapse">Show</a>
       </div>
     </div>
   </div>

--- a/app/views/organization_timeline_entries/_queue_sidebar.html.erb
+++ b/app/views/organization_timeline_entries/_queue_sidebar.html.erb
@@ -1,0 +1,50 @@
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <div class='row'>
+      <div class='col-xs-9'>Queues</div>
+      <div class='col-xs-3'>
+        <a href="#sidebar-queues-widget" onclick='_toggleText(this, "Show", "Hide")'
+           class="btn btn-info btn-xs"  data-toggle="collapse">Hide</a>
+      </div>
+    </div>
+  </div>
+  <div id='sidebar-queues-widget' class="collapse panel-body">
+    <table class="table table-condensed" style="width: 50%; float: left; border-right: 1px solid #dddddd;">
+      <thead>
+        <th style="text-align: center;">Structural</th>
+      </thead>
+      <tbody>
+        <% @structural_queue_sidebar.each do |entry| %>
+          <tr class="sidebar-popover" data-toggle="popover" data-placement="left" title="Entered at <%= date_and_time entry.started_at %>" data-content='<%=h entry.description %></br><%= form_tag end_organization_timeline_entry_path(entry), method: :put do %><%= hidden_field_tag 'url', request.original_fullpath %><%= submit_tag 'Remove', class: 'btn btn-xs btn-danger' %><% end %>'>
+            <td style="text-align: center;"><%= entry.organization.short_name %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <table class="table table-condensed" style="width: 50%; border-left: 1px solid #dddddd;">
+      <thead>
+        <th style="text-align: center;">Electrical</th>
+      </thead>
+      <tbody>
+        <% @electrical_queue_sidebar.each do |entry| %>
+          <tr class="sidebar-popover" data-toggle="popover" data-placement="left" title="Entered at <%= date_and_time entry.started_at %>" data-content='<%=h entry.description %></br><%= form_tag end_organization_timeline_entry_path(entry), method: :put do %><%= hidden_field_tag 'url', request.original_fullpath %><%= submit_tag 'Remove', class: 'btn btn-xs btn-danger' %><% end %>'>
+            <td style="text-align: center;"><%= entry.organization.short_name %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <div style="width: 100%; height: 0px; clear: both; border-top: 1px solid #dddddd;"></div>
+    <h5>Add to Queue:</h5>
+    <%= simple_form_for OrganizationTimelineEntry.new do |f| %>
+      <%= f.input_field :organization_id, :as => :select, :collection => Organization.all %>
+      <div style="width: 100%; height: 5px; clear: both;"></div>
+      <%= f.input_field :description, :as => :string %>
+      <%= hidden_field_tag 'url', request.original_fullpath %>
+      <div style="width: 100%; height: 10px; clear: both;"></div>
+      <div class="btn-group" style="width: 100%;">
+        <%= f.submit 'Structural', :class => "btn btn-default", :style => "width: 50%;" %>
+        <%= f.submit 'Electrical', :class => "btn btn-default", :style => "width: 50%;" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -4,7 +4,11 @@
 
   <% if can?(:read, OrganizationAlias) %>
     <p>
-      <strong><%=link_to "Alias(es):", organization_aliases_path(@organization) %></strong>
+      <% if can?(:create, OrganizationAlias) %>
+        <strong><%=link_to "Alias(es):", organization_aliases_path(@organization) %></strong>
+      <% else %>
+        <strong>Alias(es):</strong>
+      <% end %>
       <% unless @organization.organization_aliases.blank? %>
         <%= @organization.organization_aliases.pluck(:name).join(", ") %>
       <% end %>
@@ -26,7 +30,11 @@
       <% end %>
     </p>
   <% end %>
-  <p><Strong>Downtime Remaining: </Strong><%=link_to format_remaining_downtime(@organization.remaining_downtime), organization_downtime_index_path(@organization)%></p>
+  <% if can?(:edit, OrganizationTimelineEntry) %>
+    <p><Strong>Downtime Remaining: </Strong><%=link_to format_remaining_downtime(@organization.remaining_downtime), organization_downtime_index_path(@organization)%></p>
+  <% else %>
+    <p><Strong>Downtime Remaining: </Strong><%= format_remaining_downtime(@organization.remaining_downtime) %></p>
+  <% end %>
 </div>
 
 <%= render partial: 'show_org' %>

--- a/app/views/shifts/_shifts_sidebar.html.erb
+++ b/app/views/shifts/_shifts_sidebar.html.erb
@@ -1,0 +1,58 @@
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <div class='row'>
+      <div class='col-xs-9'>Shifts</div>
+      <div class='col-xs-3'>
+        <a href="#sidebar-shifts-widget" onclick='_toggleText(this, "Show", "Hide")'
+           class="btn btn-info btn-xs"  data-toggle="collapse">Hide</a>
+      </div>
+    </div>
+  </div>
+  <div id='sidebar-shifts-widget' class="collapse in panel-body">
+    <table class="table table-condensed" style="margin-bottom: 0;">
+      <thead>
+        <th>Current</th>
+        <th style="text-align: right;">Ends at</th>
+      </thead>
+      <tbody>
+        <% cache ['current_sidebar', @current_shifts_sidebar] do %>
+          <% @current_shifts_sidebar.each do |shift| %>
+            <tr class="sidebar-tooltip <%= shift.is_checked_in ? 'success' : 'success' %>" id="" data-toggle="tooltip" data-placement="left" title="<%= shift.shift_type.name %><%=h ' - ' + shift.description + ' (' + shift.required_number_of_participants.to_s + ')'  unless shift.description.blank? %>">
+              <td style="max-width: 103px; white-space: nowrap; text-overflow: ellipsis; overflow: hidden;">
+                <% if (shift.shift_type.name == "Coordinator Shift") %>
+                  <%= link_to shift.shift_participants.first.participant.name, shift unless shift.shift_participants.blank? %>
+                <% else %>
+                  <%= link_to shift.organization.short_name, shift unless shift.organization.blank? %>
+                  <%= link_to 'No Org Assigned', shift if shift.organization.blank? %>
+                <% end %>
+              </td>
+              <td style="text-align: right;"><%= time shift.ends_at %></td>
+            </tr>
+          <% end %>
+        <% end %>
+      </tbody>
+    </table>
+    <table class="table table-condensed table-striped" style="margin-bottom: 0;">
+      <thead>
+        <th>Upcoming</th>
+        <th style="text-align: right;">Starts at</th>
+      </thead>
+      <tbody>
+        <% cache ['upcoming_sidebar', @upcoming_shifts_sidebar] do %>
+          <% @upcoming_shifts_sidebar.each do |shift| %>
+            <tr class="sidebar-tooltip <%= shift.is_checked_in ? 'success' : 'warning' %>" id="" data-toggle="tooltip" data-placement="left" title="<%= shift.shift_type.name %><%=h ' - ' + shift.description + ' (' + shift.required_number_of_participants.to_s + ')'  unless shift.description.blank? %>">
+              <td style="max-width: 103px; white-space: nowrap; text-overflow: ellipsis; overflow: hidden;">
+                <% if (shift.shift_type.name == "Coordinator Shift") %>
+                  <%= link_to shift.shift_participants.first.participant.name, shift unless shift.shift_participants.blank? %>
+                <% else %>
+                  <%= link_to shift.organization.short_name, shift unless shift.organization.blank? %>
+                 <% end %>
+              </td>
+              <td style="text-align: right;"><%= time shift.starts_at %></td>
+            </tr>
+          <% end %>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/shifts/_shifts_sidebar.html.erb
+++ b/app/views/shifts/_shifts_sidebar.html.erb
@@ -17,7 +17,7 @@
       <tbody>
         <% cache ['current_sidebar', @current_shifts_sidebar] do %>
           <% @current_shifts_sidebar.each do |shift| %>
-            <tr class="sidebar-tooltip <%= shift.is_checked_in ? 'success' : 'success' %>" id="" data-toggle="tooltip" data-placement="left" title="<%= shift.shift_type.name %><%=h ' - ' + shift.description + ' (' + shift.required_number_of_participants.to_s + ')'  unless shift.description.blank? %>">
+            <tr class="sidebar-tooltip <%= shift.is_checked_in ? 'success' : 'danger' %>" id="" data-toggle="tooltip" data-placement="left" title="<%= shift.shift_type.name %><%=h ' - ' + shift.description + ' (' + shift.required_number_of_participants.to_s + ')'  unless shift.description.blank? %>">
               <td style="max-width: 103px; white-space: nowrap; text-overflow: ellipsis; overflow: hidden;">
                 <% if (shift.shift_type.name == "Coordinator Shift") %>
                   <%= link_to shift.shift_participants.first.participant.name, shift unless shift.shift_participants.blank? %>

--- a/app/views/tasks/_tasks_sidebar.html.erb
+++ b/app/views/tasks/_tasks_sidebar.html.erb
@@ -1,0 +1,32 @@
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <div class='row'>
+    <div class='col-xs-9'>Tasks</div>
+    <div class='col-xs-3'>
+      <a href="#sidebar-tasks-widget" onclick='_toggleText(this, "Show", "Hide")'
+         class="btn btn-info btn-xs"  data-toggle="collapse">Hide</a>
+    </div>
+  </div>
+  </div>
+  <div id='sidebar-tasks-widget' class="collapse in panel-body">
+    <table class="table table-condensed" style="margin-bottom: 0;">
+      <thead>
+        <th>Title</th>
+        <th style="text-align: right;">Due By</th>
+        <th style="text-align: center;">Action</th>
+      </thead>
+      <tbody>
+        <% @tasks_sidebar.each do |task| %>
+          <tr class="sidebar-tooltip" data-toggle="tooltip" data-placement="left" title="<%=h task.name %>: <%=h task.description %>">
+            <td style="max-width: 103px; white-space: nowrap; text-overflow: ellipsis; overflow: hidden;"><%=h task.name %></td>
+            <td style="text-align: right;"><%= time task.due_at%></td>
+            <% if can?(:update, task) %>
+              <td style="text-align: center;"><%= link_to t('.complete', :default => t("helpers.links.complete")),
+                  complete_task_path(task), :method => :post, :class => 'btn btn-xs btn-success' %></td>
+            <% end %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/tool_cart/_tool_cart.html.erb
+++ b/app/views/tool_cart/_tool_cart.html.erb
@@ -1,69 +1,77 @@
 <div class="panel panel-default">
   <div class="panel-heading">
-    Tool Cart
+    <div class='row'>
+      <div class='col-xs-9'>Tool Cart</div>
+      <div class='col-xs-3'>
+        <a href="#tc_actions" onclick='_toggleText(this, "Show", "Hide")'
+           class="btn btn-info btn-xs"  data-toggle="collapse">Hide</a>
+      </div>
+    </div>
   </div>
 
   <div id='tc_alert' class='panel-body' style='display: none'>
     <span id='tc_alert_message'>The checkout was unsuccessful. Please try again at another time or ask someone for help.</span>
   </div>
 
-  <div id='tc_scan_tools_action' class='panel-body'>
-    <%= form_tag(tool_cart_add_tool_path, method: :post, remote: true) do %>
-      <label for='tc_scan_tool'>Scan Tools</label>
-      <input id='tc_scan_tool' autocomplete="off" name="barcode" type='text' style='width: 100%' />
-    <% end %>
-    <div id='tc_tool_list_container' style='margin-bottom: 2px; <%= @tool_cart.empty? ? raw("display: none'"): ''%>'>
-      <br />
-      <div class="row">
-        <div class='col-xs-3'><strong>Barcode</strong></div>
-        <div class='col-xs-6'><strong>Name</strong></div>
-        <div class='col-xs-3'></div>
-      </div>
-      <div id="tc_tool_list" style="overflow: auto; max-height: 300px">
-        <% @tool_cart.each do |tool| %>
-          <%= render partial: 'tool_cart/tool_cart_item', locals: {tool: tool} %>
-        <% end %>
-      </div>
-    </div>
-    <br />
-    <div class="btn-group" style="width: 100%">
-      <%= button_tag 'Check Out', :class => "btn btn-primary cart-button", onclick: 'ToolCart.checkoutAction()'%>
-      <%= link_to 'Swap', tool_cart_swap_path, method: :post, remote: true,
-                     :class => "btn btn-primary cart-button", :style => "padding-top: 14px",
-                     'data-toggle' => 'tooltip', 'data-placement' => 'bottom',
-                     title: 'Scan one checked out tool and one checked in tool then hit swap to swap them!'%>
-      <%= link_to 'Check In', tool_cart_checkin_path, method: :post, remote: true, :class => "btn btn-primary cart-button" %>
-    </div>
-  </div>
-
-  <div id='tc_checkout_action' class="panel-body" style='display: none'>
-    <%= form_tag tool_cart_checkout_path, method: :post, remote: true, id: 'tc_checkout_form' do %>
-      <div id='tc_checkout_scan_andrewid_div'>
-        <label for='tc_checkout_scan_andrewid'>Scan Andrew ID: </label>
-        <input id='tc_checkout_scan_andrewid' autocomplete="off" type='text' style='width: 100%' />
-      </div>
-
-      <br />
-      <div id='tc_checkout_loaded_participant_div' style='display: none'>
-        <span><strong>Checkout <span id='tc_checkout_tools_count'></span> to: </strong></span><br />
-        <span id='tc_checkout_loaded_participant' style='font-weight: bold; font-size: 1.4em; color: black'>Israel Madueme</span><br />
-        <input id='tc_checkout_loaded_participant_id' name='participant_id' type='hidden' />
-
+  <div id='tc_actions' class='collapse in'>
+    <div id='tc_scan_tools_action' class='panel-body'>
+      <%= form_tag(tool_cart_add_tool_path, method: :post, remote: true) do %>
+        <label for='tc_scan_tool'>Scan Tools</label>
+        <input id='tc_scan_tool' autocomplete="off" name="barcode" type='text' style='width: 100%' />
+      <% end %>
+      <div id='tc_tool_list_container' style='margin-bottom: 2px; <%= @tool_cart.empty? ? raw("display: none'"): ''%>'>
         <br />
-        <label for='tc_checkout_select_organization'>Select Organization: </label>
-        <select id='tc_checkout_select_organization' name='organization_id' style='width: 100%'>
-        </select>
-        <div id='tc_checkout_add_membership_div' style='display: none'>
-          <span>Add Membership?</span>
-          <input id='tc_checkout_add_membership' name='add_membership' type='checkbox' />
+        <div class="row">
+          <div class='col-xs-3'><strong>Barcode</strong></div>
+          <div class='col-xs-6'><strong>Name</strong></div>
+          <div class='col-xs-3'></div>
+        </div>
+        <div id="tc_tool_list" style="overflow: auto; max-height: 300px">
+          <% @tool_cart.each do |tool| %>
+            <%= render partial: 'tool_cart/tool_cart_item', locals: {tool: tool} %>
+          <% end %>
         </div>
       </div>
-
       <br />
-      <%= button_tag 'Checkout Tools', class: 'btn btn-success', style: 'width: 60%' %>
-      <%= button_tag 'Cancel', type: :button, onclick: 'ToolCart.scanToolsAction()', class: 'btn btn-default', style: 'width: 30%; float: right' %>
-      <br style='clear: both' />
-    <% end %>
+      <div class="btn-group" style="width: 100%">
+        <%= button_tag 'Check Out', :class => "btn btn-primary cart-button", onclick: 'ToolCart.checkoutAction()'%>
+        <%= link_to 'Swap', tool_cart_swap_path, method: :post, remote: true,
+                       :class => "btn btn-primary cart-button", :style => "padding-top: 14px",
+                       'data-toggle' => 'tooltip', 'data-placement' => 'bottom',
+                       title: 'Scan one checked out tool and one checked in tool then hit swap to swap them!'%>
+        <%= link_to 'Check In', tool_cart_checkin_path, method: :post, remote: true, :class => "btn btn-primary cart-button" %>
+      </div>
+    </div>
+
+    <div id='tc_checkout_action' class="panel-body" style='display: none'>
+      <%= form_tag tool_cart_checkout_path, method: :post, remote: true, id: 'tc_checkout_form' do %>
+        <div id='tc_checkout_scan_andrewid_div'>
+          <label for='tc_checkout_scan_andrewid'>Scan Andrew ID: </label>
+          <input id='tc_checkout_scan_andrewid' autocomplete="off" type='text' style='width: 100%' />
+        </div>
+
+        <br />
+        <div id='tc_checkout_loaded_participant_div' style='display: none'>
+          <span><strong>Checkout <span id='tc_checkout_tools_count'></span> to: </strong></span><br />
+          <span id='tc_checkout_loaded_participant' style='font-weight: bold; font-size: 1.4em; color: black'>Israel Madueme</span><br />
+          <input id='tc_checkout_loaded_participant_id' name='participant_id' type='hidden' />
+
+          <br />
+          <label for='tc_checkout_select_organization'>Select Organization: </label>
+          <select id='tc_checkout_select_organization' name='organization_id' style='width: 100%'>
+          </select>
+          <div id='tc_checkout_add_membership_div' style='display: none'>
+            <span>Add Membership?</span>
+            <input id='tc_checkout_add_membership' name='add_membership' type='checkbox' />
+          </div>
+        </div>
+
+        <br />
+        <%= button_tag 'Checkout Tools', class: 'btn btn-success', style: 'width: 60%' %>
+        <%= button_tag 'Cancel', type: :button, onclick: 'ToolCart.scanToolsAction()', class: 'btn btn-default', style: 'width: 30%; float: right' %>
+        <br style='clear: both' />
+      <% end %>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
- Slightly reorganized the nav bar menus to be more intuitive.  Added downtime and queue links to the nav bar.  Separated links into Other Links (general links) and SCC Links (SCC-specific features). Moved the sign waiver link to the right-side user dropdown.

- Slightly reorganized the quick links page (home page).  Changed some of the buttons and added a button to sign a waiver if a user is logged in who has not signed the waiver

- Moved all sidebar widgets into partials.

- Rearranged some of the sidebar widgets, made the tool cart collapsible, and change the default state (collapsed or not) for some widgets.

- Removed the option to mark an event as completed in the form for a new event.