### PR TITLE
Updated tools page for organizations

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -12,10 +12,12 @@ class OrganizationsController < ApplicationController
   # GET /organizations/1
   # GET /organizations/1.json
   def show
-    @charges = @organization.charges.last(10)
     @booth_chairs = @organization.booth_chairs
-    @tools = Tool.checked_out_by_organization(@organization).just_tools.first(10)
-    @shifts = @organization.shifts.future.first(10)
+    @tools = Tool.checked_out_by_organization(@organization).just_tools
+    @shifts = @organization.shifts.future
+    @participants = @organization.participants
+    @documents = @organization.documents
+    @charges = @organization.charges
   end
 
   # GET /organizations/new

--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -24,7 +24,7 @@ class ToolsController < ApplicationController
       end
     else
       @tools = @tools.just_tools
-      @title = "Tools (hardhats/radios hidden)"
+      @title = "Tools"
     end
 
     # Fitler by inventory status

--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -4,6 +4,7 @@ class ToolsController < ApplicationController
   # GET /tools
   # GET /tools.json
   def index
+    @tools = Tool
     unless params[:organization_id].blank?
       @organization = Organization.find(params[:organization_id])
       @tools = Tool.checked_out_by_organization(@organization)
@@ -12,18 +13,18 @@ class ToolsController < ApplicationController
     # Filter by tools
     if params[:type_filter].present?
       if params[:type_filter].strip == 'all_tools'
-        @tools = Tool.all
+        @tools = @tools.all
         @title = "Tools (hardhats/radios included)"
       else
         @tool_type = ToolType.find(params[:type_filter])
         @title = @tool_type.name.pluralize
-        @tools = Tool.by_type(@tool_type)
+        @tools = @tools.by_type(@tool_type)
         @waitlist = @tool_type.tool_waitlists.by_wait_start_time
-        @num_available = @tools.size - @tools.checked_out.size
+        @num_available = Tool.by_type(@tool_type).size - Tool.by_type(@tool_type).checked_out.size
       end
     else
-      @tools = Tool.just_tools
-      @title = "Tools"
+      @tools = @tools.just_tools
+      @title = "Tools (hardhats/radios hidden)"
     end
 
     # Fitler by inventory status

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -27,6 +27,10 @@ class Ability
       o.participants.include?(user.participant)
     end
 
+    can :read_org_details, Organization do |o|
+      o.participants.include?(user.participant)
+    end
+
     can :read, Shift do |s|
       s.organization.participants.include?(user.participant) unless s.organization.nil?
     end
@@ -43,7 +47,7 @@ class Ability
       can :read_basic_details, Organization
 
       can :read_all_details, Organization do |o|
-        o.booth_chairs.include?(user.participant)
+        o.participants.include?(user.participant)
       end
 
       can :read, Charge do |c|

--- a/app/views/documents/_organization_document_list.html.erb
+++ b/app/views/documents/_organization_document_list.html.erb
@@ -1,4 +1,4 @@
-<% if can?(:read, Document) %>
+<% if not organization_document_list.empty? %>
   <%- model_class = Document -%>
   <table class="table table-striped">
     <thead>
@@ -9,7 +9,7 @@
       </tr>
     </thead>
     <tbody>
-      <% document_list.each do |document| %>
+      <% organization_document_list.each do |document| %>
         <% if can?(:read, document) %>
           <tr>
             <td><%= link_to(document.name, document.url.to_s) %></td>
@@ -19,8 +19,7 @@
       <% end %>
     </tbody>
   </table>
-
 <% else %>
-  <h3>Not Authorized!</h3>
+  </br>
+  This organization has no documents.
 <% end %>
-

--- a/app/views/organizations/_show_org.html.erb
+++ b/app/views/organizations/_show_org.html.erb
@@ -2,15 +2,17 @@
 <ul class="nav nav-tabs">
   <li class="active"><a href="#chairs" data-toggle="tab">Booth Chairs</a></li>
   <% if can?(:read_basic_details, @organization) %>
+    <li><a href="#members" data-toggle="tab">Members</a></li>
     <li><a href="#tools" data-toggle="tab">Tools</a></li>
     <li><a href="#shifts" data-toggle="tab">Shifts</a></li>
-    <li><a href="#members" data-toggle="tab">Members</a></li>
-    <li><a href="#documents" data-toggle="tab">Documents</a></li>
-
   <% end %>
 
   <% if can?(:read_all_details, @organization) %>
     <li><a href="#charges" data-toggle="tab">Charges</a></li>
+  <% end %>
+
+  <% if can?(:read_org_details, @organization) %>
+    <li><a href="#documents" data-toggle="tab">Documents</a></li>
   <% end %>
 </ul>
 
@@ -19,9 +21,10 @@
   <div id="chairs" class="tab-pane active">
     <%= render :partial => 'participants/organization_booth_chair_list', :object => @booth_chairs %>
   </div>
+
   <% if can?(:read_basic_details, @organization) %>
     <div id="members" class="tab-pane">
-      <%= render :partial => "participants/organization_participant_list", :object => @organization.memberships %>
+      <%= render :partial => "participants/organization_participant_list", :object => @participants %>
     </div>
     <div id="shifts" class="tab-pane">
       <%= render :partial => "shifts/organization_shift_list.html.erb", :object => @shifts %>
@@ -29,14 +32,17 @@
     <div id="tools" class="tab-pane">
       <%= render :partial => "tools/organization_tool_list", :object => @tools %>
     </div>
-    <div id="documents" class="tab-pane">
-      <%= render :partial => "organizations/document_list", :object => @organization.documents %>
-    </div>
   <% end %>
 
   <% if can?(:read_all_details, @organization) %>
     <div id="charges" class="tab-pane">
       <%= render :partial => "charges/organization_charge_list", :object => @charges %>
+    </div>
+  <% end %>
+
+  <% if can?(:read_org_details, @organization) %>
+    <div id="documents" class="tab-pane">
+      <%= render :partial => "documents/organization_document_list", :object => @documents %>
     </div>
   <% end %>
 </div>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -38,16 +38,6 @@
 <p>
   <%= link_to t('.back', :default => t("helpers.links.back")),
     organizations_path, :class => 'btn btn-default' %>
-  <% if can?(:read, Membership) %>
-    <%= link_to raw("Members"), [@organization, :participants], :class => 'btn btn-info' %>
-  <% end %>
-  <%# remove false for hardhat checkout %>
-  <% if can?(:hardhats, @organization) and false %>
-    <%= link_to raw("Hardhats"), hardhats_organization_path(@organization), :class => 'btn btn-info' %>
-  <% elsif can?(:read_all_details, @organization) %>
-    <%= link_to raw("Hardhats"), organization_tools_path(@organization, :type => "hardhats"), :class => 'btn btn-info' %>
-  <% end %>
-
   <% if can?(:update, @organization) %>
     <%= link_to t('.edit', :default => t("helpers.links.edit")),
       edit_organization_path(@organization), :class => 'btn btn-primary' %>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -38,6 +38,9 @@
 <p>
   <%= link_to t('.back', :default => t("helpers.links.back")),
     organizations_path, :class => 'btn btn-default' %>
+  <% if can?(:read_basic_details, @organization) %>
+    <%= link_to raw("Tools"), organization_tools_path(@organization), :class => 'btn btn-info' %>
+  <% end %>
   <% if can?(:update, @organization) %>
     <%= link_to t('.edit', :default => t("helpers.links.edit")),
       edit_organization_path(@organization), :class => 'btn btn-primary' %>

--- a/app/views/participants/_organization_participant_list.html.erb
+++ b/app/views/participants/_organization_participant_list.html.erb
@@ -1,4 +1,3 @@
-<% if can?(:read, Participant) %>
 <%- model_class = Participant -%>
 <table class="table table-striped">
   <thead>
@@ -12,7 +11,7 @@
     </tr>
   </thead>
   <tbody>
-    <% organization_participant_list.collect(&:participant).each do |participant| %>
+    <% @participants.each do |participant| %>
     <% if can?(:read, participant) %>
     <tr>
       <td><%= link_to participant.name, participant %></td>
@@ -26,8 +25,3 @@
     <% end %>
   </tbody>
 </table>
-
-
-<% else %>
-<h3>Not Authorized!</h3>
-<% end %>

--- a/app/views/shifts/_organization_shift_list.html.erb
+++ b/app/views/shifts/_organization_shift_list.html.erb
@@ -25,10 +25,6 @@
       <% end %>
     </tbody>
   </table>
-
-  <% if (organization_shift_list.length == 10) %>
-    <%= link_to raw("View more…"), organization_shifts_path(@organization), :class => 'btn btn-xs' %></h2>
-  <% end %>
 <% else %>
   </br>
   This organization has no shifts.

--- a/app/views/tools/_organization_tool_list.html.erb
+++ b/app/views/tools/_organization_tool_list.html.erb
@@ -1,13 +1,5 @@
-<br />
-<%= link_to raw("View all tools for #{@organization.short_name}"), organization_tools_path(@organization), :class => 'btn btn-primary' %>
 <% unless organization_tool_list.empty? %>
   <%= render partial: 'tools/tools', locals: {tools: organization_tool_list, page: "org"} %>
-  <% if (organization_tool_list.length >= 10) %>
-    <p>Only the first 10 tools are shown above, <%= link_to 'view more', organization_tools_path(@organization) %> </p>
-  <% end %>
-<% else %>
-  <br />
-  <span>This organization currently has no actual tools checked out.</span><br />
 <% end %>
-<span>This organization has <%= pluralize(Tool.checked_out_by_organization(@organization).hardhats.count, 'hardhat') %>  checked out.</span><br />
-<span>This organization has <%= pluralize(Tool.checked_out_by_organization(@organization).radios.count, 'radio') %> checked out.</span><br />
+<span>This organization currently has <%= pluralize(Tool.checked_out_by_organization(@organization).just_tools.count, 'tools') %>, <%= pluralize(Tool.checked_out_by_organization(@organization).hardhats.count, 'hardhat') %>, and <%= pluralize(Tool.checked_out_by_organization(@organization).radios.count, 'radio') %> checked out. <%= link_to "View all", organization_tools_path(@organization) %></span>
+

--- a/app/views/tools/_organization_tool_list.html.erb
+++ b/app/views/tools/_organization_tool_list.html.erb
@@ -1,11 +1,13 @@
+<br />
+<%= link_to raw("View all tools for #{@organization.short_name}"), organization_tools_path(@organization), :class => 'btn btn-primary' %>
 <% unless organization_tool_list.empty? %>
-
   <%= render partial: 'tools/tools', locals: {tools: organization_tool_list, page: "org"} %>
-  
-  <% if (organization_tool_list.length == 10) %>
-    <%= link_to raw("View more…"), organization_tools_path(@organization), :class => 'btn btn-xs' %></h2>
+  <% if (organization_tool_list.length >= 10) %>
+    <p>Only the first 10 tools are shown above, <%= link_to 'view more', organization_tools_path(@organization) %> </p>
   <% end %>
 <% else %>
   <br />
-  This organization currently has no tools checked out.
+  <span>This organization currently has no actual tools checked out.</span><br />
 <% end %>
+<span>This organization has <%= pluralize(Tool.checked_out_by_organization(@organization).hardhats.count, 'hardhat') %>  checked out.</span><br />
+<span>This organization has <%= pluralize(Tool.checked_out_by_organization(@organization).radios.count, 'radio') %> checked out.</span><br />

--- a/app/views/tools/_tools.html.erb
+++ b/app/views/tools/_tools.html.erb
@@ -21,9 +21,15 @@
 </table>
 
 <% if tools.empty? %>
-  <div class="alert alert-info">
-      There are no <%= param_equals_s(:inventory_filter, 'checked_out') ? raw('<strong>Checked Out</strong>') : '' %>
-    <%= param_equals_s(:inventory_filter, 'checked_in') ? raw('<strong>Checked In</strong>') : '' %>
-   <%= @title %> at this time. <%= link_to raw("<strong>See All #{@title}</strong>"), tools_path(type_filter: params[:type_filter]) %>
-  </div>
+    <% if organization.present? %>
+      <div class="alert alert-info">
+          <%= organization.name %> does not have any <%= @title %> checked out at this time. <%= link_to raw("<strong>See all tools</strong>"), organization_tools_path(@organization, type_filter: 'all_tools') %>
+      </div>
+    <% else %>
+      <div class="alert alert-info">
+          There are no <%= param_equals_s(:inventory_filter, 'checked_out') ? raw('<strong>Checked Out</strong>') : '' %>
+        <%= param_equals_s(:inventory_filter, 'checked_in') ? raw('<strong>Checked In</strong>') : '' %>
+       <%= @title %> at this time. <%= link_to raw("<strong>See All #{@title}</strong>"), tools_path(type_filter: params[:type_filter]) %>
+      </div>
+    <% end %>
 <% end %>

--- a/app/views/tools/index.html.erb
+++ b/app/views/tools/index.html.erb
@@ -7,27 +7,37 @@
 </div>
 
 <div>
-  <form action='<%= tools_path %>' method='get'>
+  <form action='<%= @organization.present? ? organization_tools_path(@organization) : tools_path %>' method='get'>
     <div style='float: left; border: 1px solid #ccc; border-radius: 4px; padding: 6px; margin-right: 8px;'>
       <span style='font-weight: bold; margin-right: 5px'>Filter by Tool Type</span><br />
       <select name='type_filter' class='form-control' onchange='this.form.submit()'>
         <%= raw("<option value='' #{params[:type_filter].present? ? '':'selected'}>All tools (except hardhats/radios)</option>") %>
         <%= raw("<option value='all_tools' #{param_equals_s(:type_filter, 'all_tools') ? 'selected':''}>All tools (Include hardhats/radios)</option>") %>
-        <% ToolType.all.to_a.each do |tool_type| %>
-          <%= raw("<option value='#{tool_type.id}' #{param_equals_i(:type_filter, tool_type.id) ? 'selected' : ''}>#{tool_type.name}</option>") %>
+
+        <% if @organization.present? %>
+          <% Tool.checked_out_by_organization(@organization).map{|t| t.tool_type}.uniq.each do |tool_type| %>
+            <%= raw("<option value='#{tool_type.id}' #{param_equals_i(:type_filter, tool_type.id) ? 'selected' : ''}>#{tool_type.name}</option>") %>
+          <% end %>
+        <% else %>
+          <% ToolType.all.to_a.each do |tool_type| %>
+            <%= raw("<option value='#{tool_type.id}' #{param_equals_i(:type_filter, tool_type.id) ? 'selected' : ''}>#{tool_type.name}</option>") %>
+          <% end %>
         <% end %>
       </select>
       </div>
-    <div style='float: left; border: 1px solid #ccc; border-radius: 4px; padding: 6px; margin-right: 8px;'>
-      <span style='font-weight: bold; margin-right: 5px'>Filter Checked Out Status </span><br />
-      <select name='inventory_filter' class='form-control' onchange='this.form.submit()'>
-        <%= raw("<option value='' #{params[:inventory_filter].present? ? '':'selected'}>All</option>") %>
-        <%= raw("<option value='checked_in' #{(params[:inventory_filter].present? && params[:inventory_filter] == 'checked_in') ? 'selected':''}>Checked In Only</option>") %>
-        <%= raw("<option value='checked_out' #{(params[:inventory_filter].present? && params[:inventory_filter] == 'checked_out') ? 'selected':''}>Checked Out Only</option>") %>
-      </select>
-    </div>
+
+    <% unless @organization.present? %>
+      <div style='float: left; border: 1px solid #ccc; border-radius: 4px; padding: 6px; margin-right: 8px;'>
+        <span style='font-weight: bold; margin-right: 5px'>Filter Checked Out Status </span><br />
+        <select name='inventory_filter' class='form-control' onchange='this.form.submit()'>
+          <%= raw("<option value='' #{params[:inventory_filter].present? ? '':'selected'}>All</option>") %>
+          <%= raw("<option value='checked_in' #{(params[:inventory_filter].present? && params[:inventory_filter] == 'checked_in') ? 'selected':''}>Checked In Only</option>") %>
+          <%= raw("<option value='checked_out' #{(params[:inventory_filter].present? && params[:inventory_filter] == 'checked_out') ? 'selected':''}>Checked Out Only</option>") %>
+        </select>
+      </div>
+    <% end %>
   </form>
-  <%= link_to raw("Reset"), tools_path, :class => 'btn btn-default' %>
+  <%= link_to raw("Reset"), @organization.present? ? organization_tools_path(@organization) : tools_path, :class => 'btn btn-default' %>
   <% if can?(:create, Tool) and @organization.blank? %>
     <%= link_to t('.new', :default => t("helpers.links.new")),
             new_tool_path,
@@ -68,6 +78,6 @@
       </div>
     <% end %>
 <% end %>
-<%= render partial: 'tools', locals: {tools: @tools} %>
+<%= render partial: 'tools', locals: {tools: @tools, organization: @organization} %>
 
 <%= will_paginate @tools, renderer: BootstrapPagination::Rails %>


### PR DESCRIPTION
This fixes #170.

I've implemented this according to the recommendation in the issue page.
- On the organization show page the hardhats and member buttons are removed.
- A button to view all tools checked out for the org has been added to the tools tab and it always is displayed.
- An additional comment that appears when more than 10 tools are listed (the maximum number shown on the tools tab) was added to.
- A summary of how many hardhats and radios an org has checked out was added to the tools tab.
- On the full blown tools page for an org the page only shows tools checked out by the org and the tool type filter works. The tool type filter will only list options of tool types of tools that the org actually checked out.

Tested that the normal tools page works too.