### PR TITLE
Added reports to pull late or missed shifts

### DIFF
--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -36,6 +36,11 @@ class Shift < ActiveRecord::Base
   scope :current, lambda { where("starts_at < ? and ends_at > ?", Time.zone.now, Time.zone.now ) }
   scope :future, lambda { where("starts_at > ?", Time.zone.now ) }
   scope :upcoming, lambda { where("starts_at > ? and starts_at < ?", Time.zone.now, Time.zone.now + 4.hours ) }
+  scope :past, lambda { where("ends_at < ?", Time.zone.now) }
+  scope :missed, lambda { where("required_number_of_participants > (
+                                    SELECT COUNT(*)
+                                    FROM shift_participants
+                                    WHERE shift_participants.shift_id = shifts.id)")}
 
   #scopes for each type of shift, selected by their shift_type ID
   scope :watch_shifts, -> { where('shift_type_id = ?', 1) }

--- a/app/models/shift_participant.rb
+++ b/app/models/shift_participant.rb
@@ -28,6 +28,8 @@ class ShiftParticipant < ActiveRecord::Base
   belongs_to :shift, :touch => true
   belongs_to :participant, :touch => true
 
+  scope :checked_in_late, lambda{ joins(:shift).where('starts_at < ? AND clocked_in_at > starts_at', Time.zone.now)}
+
   # For lookups
   def card_number=( card_number )
     @card_number = card_number

--- a/app/reports/list_late_shifts_report.rb
+++ b/app/reports/list_late_shifts_report.rb
@@ -1,0 +1,47 @@
+class ListLateShiftsReport < Dossier::Report
+  # Don't forget to restart server to test changes to reports.
+  # If the shift times are off in this report make sure that the timezones
+  # on the mysql server are properly setup by running the following command in the shell:
+  # mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root mysql
+
+  def self.binder_report_info
+    {
+        title: "List late shifts",
+        description: "Lists people who were late to a shift.
+                      <strong>Choose to either show late shifts or missed.</strong>",
+        params: [
+            { name: :show_late_or_missed, type: :select,
+              choices: [['Late', 'late'], ['Missed', 'missed']]}
+        ]
+    }
+  end
+
+  def sql
+    if options[:show_late_or_missed] == 'late'
+      ShiftParticipant.joins(:participant, shift: [:organization, :shift_type])
+          .checked_in_late
+          .select('organizations.name AS \'Organization\'',
+                  'DATE_FORMAT(CONVERT_TZ (starts_at, \'UTC\', \'US/Eastern\'), \'%m/%d/%Y %h:%i %p\') AS \'Shift Start\'',
+                  'DATE_FORMAT(CONVERT_TZ (clocked_in_at, \'UTC\', \'US/Eastern\') , \'%m/%d/%Y %h:%i %p\') AS \'Time Clocked In\'',
+                  'TIMESTAMPDIFF(MINUTE, starts_at, clocked_in_at) AS \'Minutes Late\'',
+                  'andrewid AS \'Andrew ID\'',
+                  'shift_types.name AS \'Shift Type\'')
+          .reorder('organizations.name, starts_at')
+          .to_sql
+    else
+      Shift.joins(:organization, :shift_type)
+          .past
+          .missed
+          .select('organizations.name AS \'Organization\'',
+                  'DATE_FORMAT(CONVERT_TZ (starts_at, \'UTC\', \'US/Eastern\'), \'%m/%d/%Y %h:%i %p\') AS \'Shift Start\'',
+                  '(required_number_of_participants - (
+                      SELECT COUNT(*)
+                      FROM shift_participants
+                      WHERE shift_participants.shift_id = shifts.id)
+                   ) AS \'Number of Slots Missed\'',
+                  'shift_types.name AS \'Shift Type\'')
+          .reorder('organizations.name, starts_at')
+          .to_sql
+    end
+  end
+end

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -13,7 +13,7 @@
       </div>
       <div id="collapse<%= index %>" class="panel-collapse collapse">
         <div class="panel-body">
-          <p><%= report[:description] %></p>
+          <p><%= raw(report[:description]) %></p>
           <div class="form-inputs">
             <%= form_tag report[:url], method: :get do |f| %>
                 <%= hidden_field_tag "options[footer]", value: 1 %>


### PR DESCRIPTION
Fixes issue #190.
I created 1 report with an option to show either the missed shifts or late shifts. (Cannot show both on the same spreadsheet due to technical problems).

### ------> Important
If the times are messed up in the reports it is likely due to mysql timezones not being setup properly on the server. Because MySQL is storing times as UTC by default I had to add a function to convert the times to Eastern time.

You may ask, why? Doesn't ActiveRecord do this for us. Normally, yes, but because Dossier uses raw sql, Dossier isn't doing the normal conversions. Thus we must manually do them.

Who ever is deploying this will need to first check whether the times are correct on the reports (if they aren't you'll see shifts normally at 9pm be at 1am or something like that) OR you will not see any shift times at all because of the time conversion failing.

If they aren't correct, remote into the server and run  `mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root mysql`. You may need to change the latter half with the correct username and password for mysql on the server.

After that, you'll need to restart the rails server and it should be good to go.