### PR TITLE
Update to use mysql2 gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,7 @@ end
 
 group :development, :staging, :production do
   gem 'newrelic_rpm'
-  gem 'mysql'
+  gem 'mysql2'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
     mini_portile2 (2.0.0)
     minitest (5.8.4)
     multi_json (1.11.2)
-    mysql (2.9.1)
+    mysql2 (0.4.4)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (3.1.1)
@@ -346,7 +346,7 @@ DEPENDENCIES
   highline
   jbuilder
   jquery-rails
-  mysql
+  mysql2
   newrelic_rpm
   omniauth
   omniauth-shibboleth

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,13 +5,13 @@
 #   gem 'sqlite3'
 #
 development:
-  adapter: mysql
+  adapter: mysql2
   encoding: utf8
   reconnect: false
   database: binder_development
   pool: 5
-  username: root
-  password:
+  username: <%= ENV["MYSQL_USERNAME"] %>
+  password: <%= ENV["MYSQL_PASSWORD"] %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -21,7 +21,7 @@ test:
   database: db/binder_test.sqlite3
 
 staging:
-  adapter: mysql
+  adapter: mysql2
   encoding: utf8
   reconnect: false
   database: binder_staging
@@ -31,7 +31,7 @@ staging:
   socket: /var/run/mysqld/mysqld.sock
 
 production:
-  adapter: mysql
+  adapter: mysql2
   encoding: utf8
   reconnect: false
   database: binder_production


### PR DESCRIPTION
The mysql gem is depreciated (hasn't been updated since 2013) and doesn't play nice with MySQL 5.7 on Ubuntu 16.04.

Furthermore, a default MySQL installation now requires a password when a non-root user is logging in as the MySQL root user ([see here](https://wiki.ubuntu.com/XenialXerus/ReleaseNotes#MySQL_5.7)).  So the development environment has been updated to read the username and password from environment variables, as it does in production. 