### PR TITLE
Group participant scopes by id to prevent duplicate participants in s...

### DIFF
--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -52,8 +52,8 @@ class Participant < ActiveRecord::Base
 
   default_scope { order('andrewid') }
   scope :search, lambda { |term| where('lower(andrewid) LIKE lower(?) OR lower(cached_name) LIKE lower(?)', "%#{term}%", "%#{term}%") }
-  scope :scc, -> { joins(:organizations).where(organizations: {name: 'Spring Carnival Committee'}) }
-  scope :exec, -> { joins(:organizations).where(organizations: {name: 'Spring Carnival Committee'}).joins(:memberships).where(memberships: {is_booth_chair: true}) }
+  scope :scc, -> { joins(:organizations).where(organizations: {name: 'Spring Carnival Committee'}).group(:id) }
+  scope :exec, -> { joins(:organizations).where(organizations: {name: 'Spring Carnival Committee'}).joins(:memberships).where(memberships: {is_booth_chair: true}).group(:id) }
 
   def start_waiver_timer
     self.waiver_start = DateTime.now


### PR DESCRIPTION
Duplicate participants appear in notes to field. Grouping scopes in participant model removes these duplicates created as a result of the table join on participants belonging to more than one org.