### PR TITLE
Fixes seeding for shifts.

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -746,8 +746,9 @@ security_shift = ShiftType.create({ name: 'Security Shift' })
 coordinator_shift = ShiftType.create({ name: 'Coordinator Shift' })
 
 SPECIAL_WATCH_SHIFTS.each { |shift| Shift.create({ shift_type: watch_shift, organization: Organization.find_by_short_name(shift[:org]), starts_at: shift[:starts_at], ends_at: shift[:starts_at] + 2.hours, required_number_of_participants: 2 }) }
+
 WATCH_SHIFTS.each_with_index do |org, i|
-  starts_at = move_on + 17.hours + (i * 4).hours
+  starts_at = move_on + 17.hours + (i * 2).hours
   Shift.create({ shift_type: watch_shift, organization: Organization.find_by_short_name(org), starts_at: starts_at, ends_at: starts_at + 2.hours, required_number_of_participants: 2 })
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -747,14 +747,14 @@ coordinator_shift = ShiftType.create({ name: 'Coordinator Shift' })
 
 SPECIAL_WATCH_SHIFTS.each { |shift| Shift.create({ shift_type: watch_shift, organization: Organization.find_by_short_name(shift[:org]), starts_at: shift[:starts_at], ends_at: shift[:starts_at] + 2.hours, required_number_of_participants: 2 }) }
 WATCH_SHIFTS.each_with_index do |org, i|
-  starts_at = move_on + 17.hours + (i * 4.hours)
+  starts_at = move_on + 17.hours + (i * 4).hours
   Shift.create({ shift_type: watch_shift, organization: Organization.find_by_short_name(org), starts_at: starts_at, ends_at: starts_at + 2.hours, required_number_of_participants: 2 })
 end
 
 SECURITY_SHIFTS.each { |shift| Shift.create({ shift_type: security_shift, description: shift[:desc], organization: Organization.find_by_short_name(shift[:org]), starts_at: shift[:starts_at], ends_at: shift[:starts_at] + 2.hours, required_number_of_participants: 2 }) }
 
 COORDINATOR_SHIFTS.each_with_index do |andrewid, i|
-  starts_at = move_on + 16.hours + (i * 4.hours)
+  starts_at = move_on + 16.hours + (i * 4).hours
   ShiftParticipant.create({
     shift: Shift.create({ shift_type: coordinator_shift, organization: scc_org, starts_at: starts_at, ends_at: starts_at + 4.hours, required_number_of_participants: 1 }),
     participant: Participant.find_by_andrewid(andrewid),


### PR DESCRIPTION
In particular, the expression `(i * 4.hours)` evaluates as an integer representing the correct number of seconds, but when adding that integer to the date it is treated as a number of days, leading to shifts spaced ~39.5 years apart.

Further, watch shifts are spaced every 2 hours, not every 4.