### PR TITLE
Quick fixes 2018

### DIFF
--- a/app/controllers/charge_types_controller.rb
+++ b/app/controllers/charge_types_controller.rb
@@ -31,7 +31,7 @@ class ChargeTypesController < ApplicationController
   def show
     respond_to do |format|
       format.html # new.html.erb
-      format.json { render :json => @charge_type.default_amount.to_json, :status => 200}
+      format.json { render :json => ActiveSupport::NumberHelper.number_to_currency(@charge_type.default_amount, unit: '', delimiter: '').to_json, :status => 200}
     end
   end
 

--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -59,7 +59,7 @@ class ChargesController < ApplicationController
 
   # GET /charges/1/edit
   def edit
-    @current_receiving_participant = @charge.receiving_participant? ? "" : @charge.receiving_participant.formatted_name
+    @current_receiving_participant = @charge.receiving_participant.nil? ? "" : @charge.receiving_participant.formatted_name
   end
 
   # POST /charges

--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -31,31 +31,32 @@ class ShiftsController < ApplicationController
   # Regular index is watch shifts by default
   def index
     if (current_user.has_role? :admin)
-      @shifts = Shift.all
+      shifts = Shift.all
     elsif (current_user.participant.is_scc?)
-      @shifts = Shift.all
+      shifts = Shift.all
     else
       @orgs = current_user.participant.memberships.map {|mem| mem.organization.id}
       unless @orgs.nil?
-        @shifts = Shift.for_organizations(@orgs)
+        shifts = Shift.for_organizations(@orgs)
       end
     end
 
     if (params[:type].blank?)
       @title = "Shifts"
-      @shifts = @shifts
+      shifts = shifts
     elsif (params[:type] == "watch")
       @title = "Watch Shifts"
-      @shifts = @shifts.watch_shifts
+      shifts = shifts.watch_shifts
     elsif (params[:type] == "security")
       @title = "Security Shifts"
-      @shifts = @shifts.sec_shifts
+      shifts = shifts.sec_shifts
     elsif (params[:type] == "coordinator")
       @title = "Coordinator Shifts"
-      @shifts = @shifts.coord_shifts
+      shifts = shifts.coord_shifts
     end
 
-    @shifts = @shifts.paginate(:page => params[:page]).per_page(20)
+    @shifts_upcoming = shifts.where("ends_at > ?", Time.now).paginate(:page => params[:upcoming_page]).per_page(15).reorder('starts_at ASC')
+    @shifts_past = shifts.where("ends_at <= ?", Time.now).paginate(:page => params[:past_page]).per_page(15).reorder('starts_at DESC')
   end
 
   # GET /shifts/1

--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -30,11 +30,15 @@ class ShiftsController < ApplicationController
   # GET /shifts.json
   # Regular index is watch shifts by default
   def index
-    unless ( params[:organization_id].blank? )
-      @organization = Organization.find(params[:organization_id])
-      @shifts = @organization.shifts
+    if (current_user.has_role? :admin)
+      @shifts = Shift.all
+    elsif (current_user.participant.is_scc?)
+      @shifts = Shift.all
     else
-      @shifts = Shift
+      @orgs = current_user.participant.memberships.map {|mem| mem.organization.id}
+      unless @orgs.nil?
+        @shifts = Shift.for_organizations(@orgs)
+      end
     end
 
     if (params[:type].blank?)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,25 +34,17 @@ module ApplicationHelper
     number_to_currency(display_currency)
   end
 
-  def format_downtime(downtime)
-    downtime = downtime.to_i
-    hours = downtime / 3600
-    minutes = (downtime % 3600) / 60
-    return ("%d" % hours) + ":" + ("%02d" % minutes)
-  end
-
-  def format_remaining_downtime(downtime)
-    downtime = downtime.to_i
-    if downtime < 0
-      neg = '-'
-      downtime *= -1
+  def format_duration(time)
+    time = time.to_i
+    if time < 0
+      neg = '&minus;'.html_safe
+      time *= -1
     else
       neg = ''
     end
 
-    downtime += 59
-    hours = downtime / 3600
-    minutes = (downtime % 3600) / 60
+    hours = time / 3600
+    minutes = (time % 3600) / 60
     return neg + ("%d" % hours) + ":" + ("%02d" % minutes)
   end
 

--- a/app/helpers/shifts_helper.rb
+++ b/app/helpers/shifts_helper.rb
@@ -23,4 +23,9 @@
 #
 
 module ShiftsHelper
+
+  def current? shift
+    shift.starts_at <= Time.now and shift.ends_at > Time.now
+  end
+
 end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -70,6 +70,14 @@ class Shift < ActiveRecord::Base
     return participants.size == required_number_of_participants
   end
 
+  def self.for_organizations(organizations)
+    if (organizations.nil?)
+      all
+    else
+      where("organization_id IN (?)", organizations)
+    end
+  end
+
   def when_to_run_normal
     self.starts_at - @@notify
   end

--- a/app/views/charge_types/_form.html.erb
+++ b/app/views/charge_types/_form.html.erb
@@ -6,7 +6,7 @@
   <%= f.input :default_amount do %>
     <div class="input-group">
   		<%= content_tag :span, "$", :class => 'input-group-addon' %>
-  		<%= f.input_field :default_amount, :as => :string %>
+  		<%= f.input_field :default_amount, :as => :string, :value => number_to_currency(f.object.default_amount, unit: '', delimiter: '') %>
     </div>
   <% end %>
   <%= f.input :description, :as => :text, textarea: "{ font-size:16px; }" %>

--- a/app/views/charges/_form.html.erb
+++ b/app/views/charges/_form.html.erb
@@ -27,7 +27,7 @@ When adding a charge, please ensure that you add a detailed description. This al
 
     <%= f.input :receiving_participant do %>
       <%= f.input_field :receiving_participant_id, as: :hidden %>
-      <%= text_field_tag 'card-number-input', nil, placeholder: @current_receiving_participant, class: 'form-control'%>
+      <%= text_field_tag 'card-number-input', nil, value: @current_receiving_participant, placeholder: 'Tap card or enter andrewid...', class: 'form-control'%>
       <div id="participant-info"></div>
     <% end %>
   </div>

--- a/app/views/charges/_form.html.erb
+++ b/app/views/charges/_form.html.erb
@@ -17,7 +17,7 @@ When adding a charge, please ensure that you add a detailed description. This al
     <%= f.input :amount do %>
       <div class="input-group">
   			<%= content_tag :span, "$", :class => 'input-group-addon' %>
-  			<%= f.input_field :amount, :as => :string %>
+  			<%= f.input_field :amount, :as => :string, :value => number_to_currency(f.object.amount, unit: '', delimiter: '') %>
       </div>
 		<% end %>
 

--- a/app/views/charges/index.html.erb
+++ b/app/views/charges/index.html.erb
@@ -39,7 +39,7 @@
           <td><%= link_to "show", charge, class: 'btn btn-info btn-xs' %></td>
           <td><%= charge.charge_type.name %></td>
           <td><%= number_to_currency charge.amount %></td>
-          <td><%= link_to charge.organization.short_name, charge.organization unless !@organization.blank? %></td>
+          <td><%= link_to charge.organization.short_name, organization_charges_path(charge.organization) unless !@organization.blank? %></td>
           <td class="hidden-xs"><%= date_and_time(charge.charged_at) %></td>
           <% if can?(:approve, Charge) %>
             <td class="hidden-xs">

--- a/app/views/home/downtime.html.erb
+++ b/app/views/home/downtime.html.erb
@@ -17,8 +17,8 @@
       <tr <%= raw("class='danger'") if organization.remaining_downtime < 0 %>>
         <td><%= link_to organization.short_name, organization_downtime_index_path(organization) %></td>
         <td><%= organization.organization_category.name %></td>
-        <td style="text-align: right;"><%= format_downtime organization.downtime %></td>
-        <td style="text-align: right;"><%= format_remaining_downtime organization.remaining_downtime %></td>
+        <td style="text-align: right;"><%= format_duration organization.downtime %></td>
+        <td style="text-align: right;"><%= format_duration organization.remaining_downtime %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/home/search.html.erb
+++ b/app/views/home/search.html.erb
@@ -1,7 +1,9 @@
 <h2>Search result for term <em>'<%= @query %>'</em> </h2>
 <p class="supertiny">&nbsp;</p>
+<% result_shown = false %>
 
 <% unless @new_participant.blank? or !can?(:create, Participant) %>
+  <% result_shown = true %>
   <p>
     <%= simple_form_for @new_participant do |f| %>
       <%= f.input :andrewid, :input_html => { :value => @new_participant.andrewid }, :as => :hidden %>
@@ -11,23 +13,26 @@
 <% end %>
 
 <% unless @tools.blank? %>
-	<p><em><strong>Tools matching term '<%= @query %>'</strong></em></p>
-  <%= render partial: "tools/tools", locals: {tools: @tools} %>
-	<p class="smtext">&nbsp;</p>
+  <% result_shown = true %>
+  <p><em><strong>Tools matching term '<%= @query %>'</strong></em></p>
+    <%= render partial: "tools/tools", locals: {tools: @tools} %>
+  <p class="smtext">&nbsp;</p>
 <% end %>
 
 <% unless @participants.blank? %>
-	<p><em><strong>Participants matching term '<%= @query %>'</strong></em></p>
-	<ul>
-		<% for participant in @participants do %>
-			<li><%= link_to participant.formatted_name, participant %></li>
-		<% end %>
-	</ul>
-	<p class="supertiny">&nbsp;</p>
+  <% result_shown = true %>
+  <p><em><strong>Participants matching term '<%= @query %>'</strong></em></p>
+  <ul>
+    <% for participant in @participants do %>
+      <li><%= link_to participant.formatted_name, participant %></li>
+    <% end %>
+  </ul>
+  <p class="supertiny">&nbsp;</p>
 <% end %>
 
 <% unless @organizations.blank? and @organization_aliases.blank? %>
-	<p><em><strong>Organizations matching term '<%= @query %>'</strong></em></p>
+  <% result_shown = true %>
+  <p><em><strong>Organizations matching term '<%= @query %>'</strong></em></p>
   <ul>
     <% unless @organizations.blank? %>
       <li><em>Names matching term '<%= @query %>'</em></li>
@@ -51,24 +56,29 @@
 <% end %>
 
 <% unless @faqs.blank? or !can?(:read, Faq) %>
-	<p><em><strong>Frequently Asked Questions matching term '<%= @query %>'</strong></em></p>
-	<ul>
-		<% for faq in @faqs do %>
-			<li><%= link_to faq.question, faqs_path %><br> <%= "#{faq.answer}" %></li>
-		<% end %>
-	</ul>
-	<p class="supertiny">&nbsp;</p>
+  <% result_shown = true %>
+  <p><em><strong>Frequently Asked Questions matching term '<%= @query %>'</strong></em></p>
+  <ul>
+    <% for faq in @faqs do %>
+      <li><%= link_to faq.question, faqs_path %><br> <%= "#{faq.answer}" %></li>
+    <% end %>
+  </ul>
+  <p class="supertiny">&nbsp;</p>
 <% end %>
 
 <% unless @documents.blank? %>
-	<p><em><strong>Documents matching term '<%= @query %>'</strong></em></p>
-	<ul>
-		<% for doc in @documents do %>
+  <% result_shown = true %>
+  <p><em><strong>Documents matching term '<%= @query %>'</strong></em></p>
+  <ul>
+    <% for doc in @documents do %>
       <% if can?(:read, doc )%>
-  			<li><%= link_to doc.name, doc %></li>
+        <li><%= link_to doc.name, doc %></li>
       <% end %>
-		<% end %>
-	</ul>
-	<p class="supertiny">&nbsp;</p>
+    <% end %>
+  </ul>
+  <p class="supertiny">&nbsp;</p>
 <% end %>
 
+<% unless result_shown %>
+  <p><em>No results found for '<%= @query %>'</em></p>
+<% end %>

--- a/app/views/organization_timeline_entries/_downtime_sidebar.html.erb
+++ b/app/views/organization_timeline_entries/_downtime_sidebar.html.erb
@@ -20,7 +20,7 @@
           <% @downtime_sidebar.each do |entry| %>
             <tr <%= raw('class="danger"') if entry.organization.remaining_downtime < 0 %>>
               <td style="text-align: center;"><%= link_to entry.organization.short_name, organization_downtime_index_path(entry.organization) %></td>
-              <td style="text-align: right;"><span id="countdown"><%= format_remaining_downtime entry.organization.remaining_downtime %></span></td>
+              <td style="text-align: right;"><span id="countdown"><%= format_duration entry.organization.remaining_downtime %></span></td>
               <td style="text-align: right;"><%= form_tag end_organization_timeline_entry_path(entry), method: :put do %><%= hidden_field_tag 'url', request.original_fullpath %><%= submit_tag 'Stop', class: 'btn btn-xs btn-danger' %><% end %></td>
             </tr>
           <% end %>

--- a/app/views/organization_timeline_entries/_organization_timeline_entries.html.erb
+++ b/app/views/organization_timeline_entries/_organization_timeline_entries.html.erb
@@ -13,7 +13,7 @@
           <td><%=h entry.organization.short_name %></td>
           <td><%=h entry.description%></td>
           <td><%= time entry.started_at %></td>
-          <td><%= ((Time.now - entry.started_at)/3600).to_i %>:<%= (((((Time.now - entry.started_at)/3600) - ((Time.now - entry.started_at)/3600).to_i) * 60).to_i).to_i %></td>
+          <td><%= format_duration (Time.now - entry.started_at) %></td>
           <td><%= form_tag end_organization_timeline_entry_path(entry), method: :put do %><%= hidden_field_tag 'url', request.original_fullpath %><%= submit_tag 'Remove', class: 'btn btn-xs btn-danger' %><% end %></td>
         </tr>
         <tr>

--- a/app/views/organization_timeline_entries/_queue_sidebar.html.erb
+++ b/app/views/organization_timeline_entries/_queue_sidebar.html.erb
@@ -37,7 +37,7 @@
     <% if !@electrical_queue_sidebar.blank? %>
       <table class="table table-condensed">
         <thead>
-          <th style="text-align: center;">Electrical</th>
+          <th style="text-align: center;"><%= link_to 'Electrical', electrical_path %></th>
           <th style="text-align: left;">Reason</th>
           <th></th>
         </thead>

--- a/app/views/organization_timeline_entries/_queue_sidebar.html.erb
+++ b/app/views/organization_timeline_entries/_queue_sidebar.html.erb
@@ -67,7 +67,7 @@
     <%= simple_form_for OrganizationTimelineEntry.new do |f| %>
       <%= f.input_field :organization_id, :as => :select, :collection => Organization.only_categories(['Fraternity', 'Sorority', 'Independent', 'Blitz', 'Concessions']), :style => "width: 100%" %>
       <div style="width: 100%; height: 5px; clear: both;"></div>
-      <%= f.input_field :description, :as => :string, :style => "width: 100%" %>
+      <%= f.input_field :description, :as => :string, :style => "width: 100%", :placeholder => "Enter reason..." %>
       <%= hidden_field_tag 'url', request.original_fullpath %>
       <div style="width: 100%; height: 10px; clear: both;"></div>
       <div class="btn-group" style="width: 100%;">

--- a/app/views/organization_timeline_entries/index.html.erb
+++ b/app/views/organization_timeline_entries/index.html.erb
@@ -24,7 +24,7 @@
         <tr>
           <td class="hidden-xs"><%= date_and_time(entry.started_at) %></td>
           <td class="hidden-xs"><%= date_and_time entry.ended_at unless entry.ended_at.blank? %></td>
-          <td class="hidden-xs"><%= format_downtime entry.duration %></td>
+          <td class="hidden-xs"><%= format_duration entry.duration %></td>
           <% if can?(:update, OrganizationTimelineEntry) or can?(:destroy, OrganizationTimelineEntry) %>
             <td class="hidden-xs">
               <% if can?(:update, OrganizationTimelineEntry) %>

--- a/app/views/organization_timeline_entries/index.html.erb
+++ b/app/views/organization_timeline_entries/index.html.erb
@@ -10,7 +10,7 @@
   <thead>
     <tr>
       <th><%= model_class.human_attribute_name(:started_at) %></th>
-      <th><%= model_class.human_attribute_name(:ended_at) %></th>
+      <th class="hidden-xs"><%= model_class.human_attribute_name(:ended_at) %></th>
       <th>Duration</th>
       <% if can?(:update, Task) or can?(:destroy, Task) %>
           <th class="hidden-xs"><%=t '.actions', :default => t("helpers.actions") %></th>
@@ -22,9 +22,9 @@
     <% @entries.each do |entry| %>
       <% if can?(:read, entry) %>
         <tr>
-          <td class="hidden-xs"><%= date_and_time(entry.started_at) %></td>
+          <td><%= date_and_time(entry.started_at) %></td>
           <td class="hidden-xs"><%= date_and_time entry.ended_at unless entry.ended_at.blank? %></td>
-          <td class="hidden-xs"><%= format_duration entry.duration %></td>
+          <td><%= format_duration entry.duration %></td>
           <% if can?(:update, OrganizationTimelineEntry) or can?(:destroy, OrganizationTimelineEntry) %>
             <td class="hidden-xs">
               <% if can?(:update, OrganizationTimelineEntry) %>
@@ -43,4 +43,13 @@
       <% end %>
     <% end %>
   </tbody>
+
+  <tfoot>
+    <tr>
+      <th>Remaining:</th>
+      <td class="hidden-xs"></td>
+      <th><%= format_duration(@organization.remaining_downtime) %></th>
+      <td class="hidden-xs"></td>
+    </tr>
+  </tfoot>
 </table>

--- a/app/views/organizations/_organization.html.erb
+++ b/app/views/organizations/_organization.html.erb
@@ -2,7 +2,9 @@
   <td><%= link_to organization.name, organization_path(organization) %></td>
   <% if can?(:read, OrganizationStatus) %>
     <td>
-      <% if can?(:read, organization.organization_statuses.displayable.last) %>
+      <% if !organization.organization_category.is_building %>
+        &mdash;
+      <% elsif can?(:read, organization.organization_statuses.displayable.last) %>
         <%= link_to organization.organization_statuses.displayable.last.organization_status_type.name, [organization, :organization_statuses] unless organization.organization_statuses.displayable.blank? %>
       <% end %>
     </td>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -14,7 +14,7 @@
       <% end %>
     </p>
   <% end %>
-  <% if can?(:read, OrganizationStatus) %>
+  <% if can?(:read, OrganizationStatus) and @organization.organization_category.is_building %>
     <p>
       <strong>Status:</strong>
       <% unless @organization.organization_statuses.displayable.last.blank? or not can?(:read, @organization.organization_statuses.displayable.last) %>
@@ -26,9 +26,9 @@
       <% end %>
     </p>
   <% end %>
-  <% if can?(:edit, OrganizationTimelineEntry) %>
+  <% if can?(:edit, OrganizationTimelineEntry) and @organization.organization_category.is_building %>
     <p><Strong>Downtime Remaining: </Strong><%=link_to format_remaining_downtime(@organization.remaining_downtime), organization_downtime_index_path(@organization)%></p>
-  <% else %>
+  <% elsif @organization.organization_category.is_building %>
     <p><Strong>Downtime Remaining: </Strong><%= format_remaining_downtime(@organization.remaining_downtime) %></p>
   <% end %>
 </div>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -27,9 +27,9 @@
     </p>
   <% end %>
   <% if can?(:edit, OrganizationTimelineEntry) and @organization.organization_category.is_building %>
-    <p><Strong>Downtime Remaining: </Strong><%=link_to format_remaining_downtime(@organization.remaining_downtime), organization_downtime_index_path(@organization)%></p>
+    <p><Strong>Downtime Remaining: </Strong><%=link_to format_duration(@organization.remaining_downtime), organization_downtime_index_path(@organization)%></p>
   <% elsif @organization.organization_category.is_building %>
-    <p><Strong>Downtime Remaining: </Strong><%= format_remaining_downtime(@organization.remaining_downtime) %></p>
+    <p><Strong>Downtime Remaining: </Strong><%= format_duration(@organization.remaining_downtime) %></p>
   <% end %>
 </div>
 

--- a/app/views/shifts/_list.html.erb
+++ b/app/views/shifts/_list.html.erb
@@ -1,0 +1,60 @@
+<%- model_class = Shift -%>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th></th>
+      <% if params[:type].blank? %>
+        <th><%= model_class.human_attribute_name(:type) %></th>
+      <% end %>
+      <th><%= model_class.human_attribute_name(:starts_at) %></th>
+      <th class="hidden-xs"><%= model_class.human_attribute_name(:ends_at) %></th>
+      <th class="hidden-xs"><%= model_class.human_attribute_name(:required_number_of_participants) %></th>
+      <th>
+        <% if ( @organization.blank? ) %>
+          <% if ( params[:type] == "coordinator" ) %>
+            SCC Member
+          <% else %>
+            <%= model_class.human_attribute_name(:organization) %>
+          <% end %>
+        <% else %>
+          <%= model_class.human_attribute_name(:shift_type) %>
+        <% end %>
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% shifts.each do |shift| %>
+      <% if can?(:read, shift) %>
+        <% if current?(shift) %>
+          <tr class="<%= shift.is_checked_in ? 'success' : 'danger' %>">
+        <% else %>
+          <tr>
+        <% end %>
+          <td><%= link_to t('.show', :default => t("helpers.links.show")),
+                        shift_path(shift), :class => 'btn btn-info btn-xs' %></td>
+          <% if params[:type].blank? %>
+            <td><%= shift.shift_type.name %></td>
+          <% end %>
+          <td><%= date_and_time shift.starts_at %></td>
+          <td class="hidden-xs"><%= date_and_time shift.ends_at %></td>
+          <td class="hidden-xs"><%= shift.required_number_of_participants %></td>
+          <td>
+            <% if ( @organization.blank? ) %>
+              <% if ( params[:type] == "coordinator" ) %>
+                <%= link_to shift.shift_participants.first.participant.name, shift.shift_participants.first.participant unless shift.shift_participants.blank? %>
+              <% else %>
+                <%= link_to shift.organization.short_name, shift.organization unless shift.organization.blank? %>
+              <% end %>
+            <% else %>
+              <%= shift.shift_type.name %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    <% end %>
+  </tbody>
+</table>
+<span class="smtext">
+  <%= will_paginate shifts, param_name: pagination_param, renderer: BootstrapPagination::Rails %>
+</span>

--- a/app/views/shifts/index.html.erb
+++ b/app/views/shifts/index.html.erb
@@ -14,60 +14,16 @@
   <%= link_to "New", new_shift_path, :class => 'btn btn-primary' if can?(:create, Shift) %>
 </p>
 
-<table class="table table-striped">
-  <thead>
-    <tr>
-      <th></th>
-      <% if params[:type].blank? %>
-        <th><%= model_class.human_attribute_name(:type) %></th>
-      <% end %>
-      <th><%= model_class.human_attribute_name(:starts_at) %></th>
-      <th class="hidden-xs"><%= model_class.human_attribute_name(:ends_at) %></th>
-      <th class="hidden-xs"><%= model_class.human_attribute_name(:required_number_of_participants) %></th>
-      <th>
-        <% if ( @organization.blank? ) %>
-          <% if ( params[:type] == "coordinator" ) %>
-            SCC Member
-          <% else %>
-            <%= model_class.human_attribute_name(:organization) %>
-          <% end %>
-        <% else %>
-          <%= model_class.human_attribute_name(:shift_type) %>
-        <% end %>
-      </th>
-    </tr>
-  </thead>
+<h3>Current and upcoming shifts</h3>
+<% if @shifts_upcoming.any? %>
+  <%= render partial: 'shifts/list', locals: {shifts: @shifts_upcoming, pagination_param: 'upcoming_page'} %>
+<% else %>
+  No current or upcoming shifts.
+<% end %>
 
-  <tbody>
-    <% @shifts.each do |shift| %>
-      <% if can?(:read, shift) %>
-        <tr>
-          <td><%= link_to t('.show', :default => t("helpers.links.show")),
-                        shift_path(shift), :class => 'btn btn-info btn-xs' %></td>
-          <% if params[:type].blank? %>
-            <td><%= shift.shift_type.name %></td>
-          <% end %>
-          <td><%= date_and_time shift.starts_at %></td>
-          <td class="hidden-xs"><%= date_and_time shift.ends_at %></td>
-          <td class="hidden-xs"><%= shift.required_number_of_participants %></td>
-          <td>
-            <% if ( @organization.blank? ) %>
-              <% if ( params[:type] == "coordinator" ) %>
-                <%= link_to shift.shift_participants.first.participant.name, shift.shift_participants.first.participant unless shift.shift_participants.blank? %>
-              <% else %>
-                <%= link_to shift.organization.short_name, shift.organization unless shift.organization.blank? %>
-              <% end %>
-            <% else %>
-              <%= shift.shift_type.name %>
-            <% end %>
-          </td>
-        </tr>
-      <% end %>
-    <% end %>
-  </tbody>
-</table>
-
-<span class="smtext">
-  <%= will_paginate @shifts, renderer: BootstrapPagination::Rails %>
-</span>
-
+<h3>Past shifts</h3>
+<% if @shifts_past.any? %>
+  <%= render partial: 'shifts/list', locals: {shifts: @shifts_past, pagination_param: 'past_page'} %>
+<% else %>
+  No past shifts.
+<% end %>

--- a/app/views/shifts/index.html.erb
+++ b/app/views/shifts/index.html.erb
@@ -18,6 +18,9 @@
   <thead>
     <tr>
       <th></th>
+      <% if params[:type].blank? %>
+        <th><%= model_class.human_attribute_name(:type) %></th>
+      <% end %>
       <th><%= model_class.human_attribute_name(:starts_at) %></th>
       <th class="hidden-xs"><%= model_class.human_attribute_name(:ends_at) %></th>
       <th class="hidden-xs"><%= model_class.human_attribute_name(:required_number_of_participants) %></th>
@@ -41,6 +44,9 @@
         <tr>
           <td><%= link_to t('.show', :default => t("helpers.links.show")),
                         shift_path(shift), :class => 'btn btn-info btn-xs' %></td>
+          <% if params[:type].blank? %>
+            <td><%= shift.shift_type.name %></td>
+          <% end %>
           <td><%= date_and_time shift.starts_at %></td>
           <td class="hidden-xs"><%= date_and_time shift.ends_at %></td>
           <td class="hidden-xs"><%= shift.required_number_of_participants %></td>

--- a/app/views/store/items/_cart_item.html.erb
+++ b/app/views/store/items/_cart_item.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td><%= cart_item.store_item.name  %></td>
-  <td>$ <%= cart_item.price_at_purchase %></td>
+  <td><%= number_to_currency cart_item.price_at_purchase %></td>
   <td>
     <%# TODO: Inline styles & maybe change to best_in_place %>
     
@@ -18,7 +18,7 @@
     <% end %>
 
   </td>
-  <td>$ <%= cart_item.quantity_purchased * cart_item.price_at_purchase %></td>
+  <td><%= number_to_currency (cart_item.quantity_purchased * cart_item.price_at_purchase) %></td>
   <td><%= link_to t('.remove_from_cart', :default => t("helpers.links.remove_from_cart")),
 	        remove_from_cart_store_item_path(cart_item), :class => 'btn btn-danger btn-xs', method: :post  %></td>
 </tr>

--- a/app/views/store/items/_item.html.erb
+++ b/app/views/store/items/_item.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td><%= link_to item.name, item, :class => 'btn btn-info btn-xs'  %></td>
-  <td>$ <%= item.price %></td>
+  <td><%= number_to_currency item.price %></td>
   <td><%= item.quantity_available %></td>
   <td>
     <% if can?(:create, Charge) %>

--- a/app/views/store/items/show.html.erb
+++ b/app/views/store/items/show.html.erb
@@ -2,7 +2,7 @@
 <div class="page-header">
   <h1><%= @store_item.name %></h1>
   <dt><strong><%= model_class.human_attribute_name(:price) %>:</strong></dt>
-  <dd>$<%= @store_item.price %></dd>
+  <dd><%= number_to_currency @store_item.price %></dd>
   <dt><strong><%= model_class.human_attribute_name(:quantity) %>:</strong></dt>
   <dd><%= @store_item.quantity %></dd>
   

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -359,7 +359,7 @@ Faq.create([
   { question: 'I saw an ambulance take someone to the hospital. What do I do?',
     answer: 'Call the Carnival Chair, Head of Booth, and/or Head of Operations immediately.' },
   { question: 'Golf cart problem?',
-    answer: 'Call Meg Richards.' },
+    answer: 'Call Meg Richards (meribyte).' },
   { question: 'University official wants to borrow something. What do I do?',
     answer: 'Let them. They do not need to sign a waiver. Check it out to the Carnival Chair in Binder.' },
   { question: 'Madelyn Miller calls. What do I do?',

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -362,7 +362,7 @@ Faq.create([
     answer: 'Call Meg Richards (meribyte).' },
   { question: 'University official wants to borrow something. What do I do?',
     answer: 'Let them. They do not need to sign a waiver. Check it out to the Carnival Chair in Binder.' },
-  { question: 'Madelyn Miller calls. What do I do?',
+  { question: 'Melanie Lucht calls. What do I do?',
     answer: 'Listen to her. Then call the Head of Booth and relay the message.' },
   { question: 'Alumni needs something.',
     answer: 'Call the Head of Operations or Head of Marketing.' },


### PR DESCRIPTION
Quick fixes for several bits of low-hanging fruit, listed here in roughly decreasing order of visibility/importance:

* Incorporated @blinblinblin's fixes for pagination of shift views from #263.
* Split shift index into current/upcoming and past to allow a specified shift to be more easily found.
* List each shift's type on shift index when not scoping view to a particular type of shift.
* Remove build status and downtime from the org pages of non-building orgs.
* Add the remaining downtime amount to the org downtime detail page.
* Several fixes and standardizations related to the formatting of downtime, queue wait, and other durations.
* Several fixes and standardizations related to the formatting of currency amounts.
* Tweak org links in charges index to link to charges scoped to that org.
* Add some placeholder text explaining various inputs.
* Add a missing link in the Queues sidebar.
* Provide a message on the search results page if there are no results.
* A few minor tweaks to FAQs.