### PR TITLE
Queues and downtime

### DIFF
--- a/app/controllers/organization_timeline_entries_controller.rb
+++ b/app/controllers/organization_timeline_entries_controller.rb
@@ -46,6 +46,13 @@ class OrganizationTimelineEntriesController < ApplicationController
       else 'downtime'
     end
 
+    authorize! :create, @organization_timeline_entry
+
+    if @organization_timeline_entry.already_in_queue?
+      redirect_to :back, alert: "You're already on the queue!"
+      return
+    end
+
     if(@organization_timeline_entry.valid?)
       @organization_timeline_entry.save
       respond_with(@organization_timeline_entry, location: params[:url])
@@ -68,6 +75,8 @@ class OrganizationTimelineEntriesController < ApplicationController
   # PUT /organizations_timeline_entry/1/end
   # PUT /organizations_timeline_entry/1/end.json
   def end
+    authorize! :end, @organization_timeline_entry
+
     @organization_timeline_entry.ended_at = DateTime.now
     @organization_timeline_entry.save
     respond_with(@organization_timeline_entry, location: params[:url])

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -42,6 +42,8 @@ class Ability
 
     can :read, StoreItem
 
+    can [:read, :structural, :electrical], OrganizationTimelineEntry
+
     if user.participant.is_booth_chair?
       can :read, [ChargeType, Checkout, Shift]
       can :read_basic_details, Organization
@@ -64,6 +66,10 @@ class Ability
 
       can :read, ShiftParticipant do |s|
         s.shift.organization.booth_chairs.include?(user.participant)
+      end
+
+      can [:create, :end], OrganizationTimelineEntry do |e|
+        ['structural', 'electrical'].include?(e.entry_type) && e.organization.booth_chairs.include?(user.participant)
       end
     end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -71,6 +71,10 @@ class Ability
       can [:create, :end], OrganizationTimelineEntry do |e|
         ['structural', 'electrical'].include?(e.entry_type) && e.organization.booth_chairs.include?(user.participant)
       end
+
+      can :read, OrganizationStatus do |s|
+        s.organization.booth_chairs.include?(user.participant)
+      end
     end
 
     if user.participant.is_scc?

--- a/app/models/organization_timeline_entry.rb
+++ b/app/models/organization_timeline_entry.rb
@@ -20,6 +20,7 @@
 # * `index_organization_timeline_entries_on_organization_id`:
 #     * **`organization_id`**
 #
+include Messenger
 
 class OrganizationTimelineEntry < ActiveRecord::Base
   validates_presence_of :organization, :started_at, :entry_type
@@ -43,7 +44,7 @@ class OrganizationTimelineEntry < ActiveRecord::Base
   end
 
   #notifcations 
-  after_create :notifyStart
+  after_create :notifyStart, :notify_booth_committee
   after_update :notifyEnd
 
   def notifyStart
@@ -63,6 +64,13 @@ class OrganizationTimelineEntry < ActiveRecord::Base
           send_sms(chair.phone_number, "Downtime for your organization, " +organization.name+", has ended. You have "+Time.at(organization.remaining_downtime).utc.strftime("%H hours %M minutes")+" left.")
         end
       end
+    end
+  end
+
+  def notify_booth_committee
+    # post in the booth committee groupme when someone joins a queue
+    if ['structural', 'electrical'].include?(entry_type)
+      send_groupme("8a6cab13d71d09562023b48658","#{entry_type.titlecase} Queue: #{organization.short_name} needs #{description}")
     end
   end
 end

--- a/app/models/organization_timeline_entry.rb
+++ b/app/models/organization_timeline_entry.rb
@@ -68,9 +68,17 @@ class OrganizationTimelineEntry < ActiveRecord::Base
   end
 
   def notify_booth_committee
-    # post in the booth committee groupme when someone joins a queue
-    if ['structural', 'electrical'].include?(entry_type)
-      send_groupme("8a6cab13d71d09562023b48658","#{entry_type.titlecase} Queue: #{organization.short_name} needs #{description}")
+    # post in the relevant groupme when someone joins a queue
+    bot_id = case entry_type
+      when 'structural'
+        ENV["STRUCTURAL_BOT_ID"]
+      when 'electrical'
+        ENV["ELECTRICAL_BOT_ID"]
+    end
+
+    if not bot_id.nil?
+      description_text = description.blank? ? "was added" : "needs #{description}"
+      send_groupme(bot_id, "#{entry_type.titlecase} Queue: #{organization.short_name} #{description_text}")
     end
   end
 end

--- a/app/models/organization_timeline_entry.rb
+++ b/app/models/organization_timeline_entry.rb
@@ -37,6 +37,11 @@ class OrganizationTimelineEntry < ActiveRecord::Base
     return DateTime.now.to_i - started_at.to_i
   end
 
+  def already_in_queue?
+    ['structural', 'electrical'].include?(entry_type) &&
+      !organization.organization_timeline_entries.current.send(entry_type).empty?
+  end
+
   #notifcations 
   after_create :notifyStart
   after_update :notifyEnd

--- a/app/models/organization_timeline_entry.rb
+++ b/app/models/organization_timeline_entry.rb
@@ -42,17 +42,21 @@ class OrganizationTimelineEntry < ActiveRecord::Base
   after_update :notifyEnd
 
   def notifyStart
-    for chair in organization.booth_chairs
-      if chair.phone_number.length == 10
-        send_sms(chair.phone_number, "Downtime for your organization, " +organization.name+", has started.")
+    if entry_type == 'downtime'
+      for chair in organization.booth_chairs
+        if chair.phone_number.length == 10
+          send_sms(chair.phone_number, "Downtime for your organization, " +organization.name+", has started.")
+        end
       end
     end
   end
 
   def notifyEnd
-    for chair in organization.booth_chairs
-      if chair.phone_number.length == 10
-        send_sms(chair.phone_number, "Downtime for your organization, " +organization.name+", has ended. You have "+Time.at(organization.remaining_downtime).utc.strftime("%H hours %M minutes")+" left.")
+    if entry_type == 'downtime'
+      for chair in organization.booth_chairs
+        if chair.phone_number.length == 10
+          send_sms(chair.phone_number, "Downtime for your organization, " +organization.name+", has ended. You have "+Time.at(organization.remaining_downtime).utc.strftime("%H hours %M minutes")+" left.")
+        end
       end
     end
   end

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -68,6 +68,10 @@ class Participant < ActiveRecord::Base
     !memberships.booth_chairs.blank?
   end
 
+  def booth_chair_organizations
+    memberships.booth_chairs.map(&:organization) & Organization.only_categories(['Fraternity', 'Sorority', 'Independent', 'Blitz', 'Concessions'])
+  end
+
   def is_scc?
     !organizations.find_by(name: "Spring Carnival Committee").blank?
   end

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -69,7 +69,9 @@ class Participant < ActiveRecord::Base
   end
 
   def booth_chair_organizations
-    memberships.booth_chairs.map(&:organization) & Organization.only_categories(['Fraternity', 'Sorority', 'Independent', 'Blitz', 'Concessions'])
+    memberships.booth_chairs.map(&:organization).select do |org|
+      org.organization_category.is_building
+    end
   end
 
   def is_scc?

--- a/app/views/home/_quick_links.html.erb
+++ b/app/views/home/_quick_links.html.erb
@@ -33,6 +33,12 @@
   <% if can?(:read, Task) %>
     <p><%= link_to "Tasks", tasks_path, :class => "btn btn-primary" %></p>
   <% end %>
+  <% if can?(:structural, OrganizationTimelineEntry) %>
+    <p><%= link_to "Structural Queue", structural_path, :class => "btn btn-primary" %></p>
+  <% end %>
+  <% if can?(:electrical, OrganizationTimelineEntry) %>
+    <p><%= link_to "Electrical Queue", electrical_path, :class => "btn btn-primary" %></p>
+  <% end %>
 
   <br>
 

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -19,6 +19,15 @@
           <li><%= link_to "Tools", tools_path %></li>
           <li><%= link_to "Store", store_items_path %></li>
 
+          <% if current_user.participant.is_booth_chair? %>
+              <% if can?(:structural, OrganizationTimelineEntry) %>
+                <li><%= link_to "Structural", structural_path %></li>
+              <% end %>
+              <% if can?(:electrical, OrganizationTimelineEntry) %>
+                <li><%= link_to "Electrical", electrical_path %></li>
+              <% end %>
+          <% end %>
+
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">Other Links<b class="caret"></b></a>
             <ul class="dropdown-menu">
@@ -40,6 +49,14 @@
               <% if can?(:read, Task) %>
                 <li><%= link_to "Tasks", tasks_path %></li>
               <% end %>
+              <% if !current_user.participant.is_booth_chair? %>
+                <% if can?(:structural, OrganizationTimelineEntry) %>
+                  <li><%= link_to "Structural Queue", structural_path %></li>
+                <% end %>
+                <% if can?(:electrical, OrganizationTimelineEntry) %>
+                  <li><%= link_to "Electrical Queue", electrical_path %></li>
+                <% end %>
+              <% end %>
             </ul>
           </li>
 
@@ -49,12 +66,6 @@
               <ul class="dropdown-menu">
                 <% if can?(:downtime, OrganizationTimelineEntry) %>
                   <li><%= link_to "Downtime", downtime_index_path %></li>
-                <% end %>
-                <% if can?(:structural, OrganizationTimelineEntry) %>
-                  <li><%= link_to "Structural Queue", structural_path %></li>
-                <% end %>
-                <% if can?(:electrical, OrganizationTimelineEntry) %>
-                  <li><%= link_to "Electrical Queue", electrical_path %></li>
                 <% end %>
                 <% if can?(:read, Event) %>
                   <li><%= link_to "Event Log", events_path %></li>

--- a/app/views/organization_timeline_entries/_organization_timeline_entries.html.erb
+++ b/app/views/organization_timeline_entries/_organization_timeline_entries.html.erb
@@ -10,11 +10,15 @@
     <tbody>
       <% entries.each do |entry| %>
         <tr>
-          <td><%=h entry.organization.short_name %></td>
+          <td><%= link_to entry.organization.short_name, entry.organization %></td>
           <td><%=h entry.description%></td>
           <td><%= time entry.started_at %></td>
-          <td><%= ((Time.now - entry.started_at)/3600).to_i %>:<%= (((((Time.now - entry.started_at)/3600) - ((Time.now - entry.started_at)/3600).to_i) * 60).to_i).to_i %></td>
-          <td><%= form_tag end_organization_timeline_entry_path(entry), method: :put do %><%= hidden_field_tag 'url', request.original_fullpath %><%= submit_tag 'Remove', class: 'btn btn-xs btn-danger' %><% end %></td>
+          <td><%= format_downtime (Time.now - entry.started_at) %></td>
+          <td>
+            <% if can?(:end, entry) %>
+              <%= form_tag end_organization_timeline_entry_path(entry), method: :put do %><%= hidden_field_tag 'url', request.original_fullpath %><%= submit_tag 'Remove', class: 'btn btn-xs btn-danger' %><% end %>
+            <% end %>
+          </td>
         </tr>
         <tr>
         </tr>

--- a/app/views/organization_timeline_entries/_queue_add_form.html.erb
+++ b/app/views/organization_timeline_entries/_queue_add_form.html.erb
@@ -1,0 +1,15 @@
+<% if !current_user.participant.booth_chair_organizations.empty? %>
+  <%= simple_form_for OrganizationTimelineEntry.new, :html => {:class => 'form-inline'} do |f| %>
+    <%= hidden_field_tag 'url', request.original_fullpath %>
+    <div class="form-group">
+      <%= f.input_field :organization_id, :as => :select, :collection => current_user.participant.booth_chair_organizations,
+        :include_blank => false, :class => "form-control" %>
+    </div>
+    <div class="form-group">
+      <%= f.input_field :description, :as => :string, :placeholder => "Reason", :class => "form-control" %>
+    </div>
+    <%= f.button :button, 'Add to Queue', :name => 'commit', :value => queue_type, :type => 'submit',
+                 :class => "form-control btn btn-primary" %>
+  <% end %>
+<% end %>
+

--- a/app/views/organization_timeline_entries/_queue_sidebar.html.erb
+++ b/app/views/organization_timeline_entries/_queue_sidebar.html.erb
@@ -37,7 +37,7 @@
     <% if !@electrical_queue_sidebar.blank? %>
       <table class="table table-condensed">
         <thead>
-          <th style="text-align: center;">Electrical</th>
+          <th style="text-align: center;"><%= link_to 'Electrical', electrical_path %></th>
           <th style="text-align: left;">Reason</th>
           <th></th>
         </thead>

--- a/app/views/organization_timeline_entries/electrical.html.erb
+++ b/app/views/organization_timeline_entries/electrical.html.erb
@@ -1,5 +1,7 @@
 <div class="page-header">
   <h1>Electrical Queue</h1>
+
+  <%= render partial: 'queue_add_form', locals: {queue_type: 'Electrical'} %>
 </div>
 
 <%= render partial: 'organization_timeline_entries', locals: {entries: @organization_timeline_entries} %>

--- a/app/views/organization_timeline_entries/structural.html.erb
+++ b/app/views/organization_timeline_entries/structural.html.erb
@@ -1,5 +1,7 @@
 <div class="page-header">
   <h1>Structural Queue</h1>
+  
+  <%= render partial: 'queue_add_form', locals: {queue_type: 'Structural'} %>
 </div>
 
 <%= render partial: 'organization_timeline_entries', locals: {entries: @organization_timeline_entries} %>

--- a/lib/messenger.rb
+++ b/lib/messenger.rb
@@ -1,3 +1,5 @@
+require 'net/http'
+
 USER_UNSUBSCRIBED_FROM_TWILIO_ERROR_CODE = 21610
 
 module Messenger
@@ -25,6 +27,18 @@ module Messenger
         when USER_UNSUBSCRIBED_FROM_TWILIO_ERROR_CODE
           puts e.message
       end
+    end
+  end
+
+  def send_groupme(bot_id, text)
+    # Send a message using the groupme bot API: https://dev.groupme.com/tutorials/bots
+    if !Rails.env.test?
+      uri = URI.parse('https://api.groupme.com/v3/bots/post')
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      req = Net::HTTP::Post.new(uri, 'Content-Type' => 'application/json')
+      req.body = {bot_id: bot_id, text: text}.to_json
+      http.request(req)
     end
   end
 


### PR DESCRIPTION
- Only send SMS on organization timeline entry creation/end if type is downtime
- Allow any signed in user to view structural and electrical queues
- Allow booth chairs to create/end structural and electrical organization timeline entries for their organizations
- Add links to structural and electrical queues in quick links and nav bar