### PR TITLE
Don't rely on specific shift_type IDs for shift scoping.

### DIFF
--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -48,9 +48,10 @@ class Shift < ActiveRecord::Base
                                     WHERE shift_participants.shift_id = shifts.id)")}
 
   #scopes for each type of shift, selected by their shift_type ID
-  scope :watch_shifts, -> { where('shift_type_id = ?', 1) }
-  scope :sec_shifts, -> { where('shift_type_id = ?', 2) }
-  scope :coord_shifts, -> { where('shift_type_id = ?', 3) }
+  # TODO: These can almost definitely be made more elegant
+  scope :watch_shifts, -> { where('shift_type_id = ?', ShiftType.where('name = "Watch Shift"').first.id) }
+  scope :sec_shifts, -> { where('shift_type_id = ?', ShiftType.where('name = "Security Shift"').first.id) }
+  scope :coord_shifts, -> { where('shift_type_id = ?', ShiftType.where('name = "Coordinator Shift"').first.id) }
 
   @@notify = 1.hour
   @@notify2 = 5.minutes

--- a/test/unit/shift_test.rb
+++ b/test/unit/shift_test.rb
@@ -41,9 +41,9 @@ class ShiftTest < ActiveSupport::TestCase
   context "With a proper context, " do
     setup do
       # Create 3 shifts
-      @type1 = FactoryGirl.create(:shift_type, :id => 1)
-      @type2 = FactoryGirl.create(:shift_type, :id => 2)
-      @type3 = FactoryGirl.create(:shift_type, :id => 3)
+      @type1 = FactoryGirl.create(:shift_type, :id => 1, :name => "Watch Shift")
+      @type2 = FactoryGirl.create(:shift_type, :id => 2, :name => "Security Shift")
+      @type3 = FactoryGirl.create(:shift_type, :id => 3, :name => "Coordinator Shift")
 
       @upcomming = FactoryGirl.create(:shift, :shift_type_id => @type1.id, :ends_at => Time.local(2021,1,1,16,0,0), :starts_at => Time.zone.now + 1.hour)
       @future = FactoryGirl.create(:shift, :shift_type_id => @type2.id, :ends_at => Time.local(2021,1,1,16,0,0), :starts_at => Time.zone.now + 7.hour)


### PR DESCRIPTION
The new seed files for 2018 populate the shift types in a different order, so match by name instead.  This can almost definitely be made more elegant.

e.g., https://binder.springcarnival.org/shifts?type=watch currently shows the Coordinator Shifts instead of the Watch Shifts since they are the ones with `shift_type_id = 1`.