### PR TITLE
fixes drop-judgements migration

### DIFF
--- a/db/migrate/20190313163240_drop_judgements.rb
+++ b/db/migrate/20190313163240_drop_judgements.rb
@@ -1,5 +1,8 @@
 class DropJudgements < ActiveRecord::Migration
   def change
+    remove_foreign_key :judgements, :judge
+    remove_foreign_key :judgements, :judgement_category
+
     remove_reference :judgements, :judge
     remove_reference :judgements, :judgement_category
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -321,9 +321,6 @@ ActiveRecord::Schema.define(version: 20190320032323) do
 
   add_foreign_key "certifications", "certification_types"
   add_foreign_key "certifications", "participants"
-  add_foreign_key "judgements", "judgement_categories"
-  add_foreign_key "judgements", "judges"
-  add_foreign_key "judgements", "organizations"
   add_foreign_key "store_purchases", "charges"
   add_foreign_key "store_purchases", "store_items"
   add_foreign_key "tool_type_certifications", "certification_types"


### PR DESCRIPTION
Messed up the old migration by not removing foreign key references, had to edit the migration directly to fix.