### PR TITLE
Add support for decimal CSNs from MIFARE readers.

### DIFF
--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -115,11 +115,18 @@ class Participant < ActiveRecord::Base
       return person #self.find_by_andrewid(card_number)
     elsif !lookup_only and !CarnegieMellonPerson.find_by_andrewid(card_number.downcase).blank?
       return self.find_or_create_by(andrewid: card_number.downcase)
+    # PIK number from magstripe or printed on card (9 decimal digits, allow leading % character and trailing data)
     elsif card_number[/^%?\d{9}/]
       andrewid = CarnegieMellonIDCard.get_andrewid_by_card_id(card_number)
       return self.find_or_create_by(andrewid: andrewid) unless andrewid.blank?
-    elsif card_number[/^[0-9a-fA-F]{8}/]
+    # Hexadecimal CSN from MIFARE reader (8 hex digits)
+    elsif card_number[/\A[0-9a-fA-F]{8}\z/]
       andrewid = CarnegieMellonIDCard.get_andrewid_by_card_csn(card_number)
+      return self.find_or_create_by(andrewid: andrewid) unless andrewid.blank?
+    # Decimal CSN from MIFARE reader (10 decimal digits)
+    elsif card_number[/\A\d{10}\z/]
+      # Must pad to 8 hex digits for the card translation service
+      andrewid = CarnegieMellonIDCard.get_andrewid_by_card_csn(card_number.to_i.to_s(16).rjust(8,"0"))
       return self.find_or_create_by(andrewid: andrewid) unless andrewid.blank?
     end
   end


### PR DESCRIPTION
Simply convert the decimal to 8 (padded) hex digits before sending the CSN to the card translation service.

This code has been generously lifted from the card-processing code in the IDeATe Quartermaster, which I honestly originally lifted from here.  Full circle.