### PR TITLE
Change Card Lookup Ordering

### DIFF
--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -115,6 +115,11 @@ class Participant < ActiveRecord::Base
       return person #self.find_by_andrewid(card_number)
     elsif !lookup_only and !CarnegieMellonPerson.find_by_andrewid(card_number.downcase).blank?
       return self.find_or_create_by(andrewid: card_number.downcase)
+    # Decimal CSN from MIFARE reader (10 decimal digits)
+    elsif card_number[/\A\d{10}\z/]
+      # Must pad to 8 hex digits for the card translation service
+      andrewid = CarnegieMellonIDCard.get_andrewid_by_card_csn(card_number.to_i.to_s(16).rjust(8,"0"))
+      return self.find_or_create_by(andrewid: andrewid) unless andrewid.blank?
     # PIK number from magstripe or printed on card (9 decimal digits, allow leading % character and trailing data)
     elsif card_number[/^%?\d{9}/]
       andrewid = CarnegieMellonIDCard.get_andrewid_by_card_id(card_number)
@@ -122,11 +127,6 @@ class Participant < ActiveRecord::Base
     # Hexadecimal CSN from MIFARE reader (8 hex digits)
     elsif card_number[/\A[0-9a-fA-F]{8}\z/]
       andrewid = CarnegieMellonIDCard.get_andrewid_by_card_csn(card_number)
-      return self.find_or_create_by(andrewid: andrewid) unless andrewid.blank?
-    # Decimal CSN from MIFARE reader (10 decimal digits)
-    elsif card_number[/\A\d{10}\z/]
-      # Must pad to 8 hex digits for the card translation service
-      andrewid = CarnegieMellonIDCard.get_andrewid_by_card_csn(card_number.to_i.to_s(16).rjust(8,"0"))
       return self.find_or_create_by(andrewid: andrewid) unless andrewid.blank?
     end
   end


### PR DESCRIPTION
Preferentially search for CSNs, since the magstripe regexp is
greedier and will match on nfc cardreaders outputting in decimal.