### PR TITLE
Use new server for LDAP lookups.

### DIFF
--- a/app/models/carnegie_mellon_person.rb
+++ b/app/models/carnegie_mellon_person.rb
@@ -1,12 +1,12 @@
 class CarnegieMellonPerson < ActiveLdap::Base
   ldap_mapping :dn_attribute => "guid",
-               :prefix => "ou=Person",
-               :classes => ["cmuPerson"]
+               :prefix => "ou=AndrewPerson",
+               :classes => ["cmuAccountPerson"]
 
   def self.find_by_andrewid( andrewid )
     
     begin
-      person = find("cmuandrewid=#{andrewid}", :attributes => ['cmuandrewid',
+      person = find("cmuAndrewId=#{andrewid}", :attributes => ['cmuAndrewId',
                                                                'cn', 
                                                                'mail',
                                                                'sn',

--- a/app/models/carnegie_mellon_person.rb
+++ b/app/models/carnegie_mellon_person.rb
@@ -19,7 +19,8 @@ class CarnegieMellonPerson < ActiveLdap::Base
       end
 
       return person unless person[:cn] == "Merged Person"
-    rescue
+    rescue => e
+      logger.error e
       return nil
     end
   end

--- a/config/ldap.yml
+++ b/config/ldap.yml
@@ -1,19 +1,23 @@
 development:
-  host: ldap.andrew.cmu.edu
-  port: 389
-  base: dc=cmu,dc=edu
+  host: ldap.cmu.edu
+  port: 636
+  method: ssl
+  base: dc=andrew,dc=cmu,dc=edu
 
 test:
-  host: ldap.andrew.cmu.edu
-  port: 389
-  base: dc=cmu,dc=edu
+  host: ldap.cmu.edu
+  port: 636
+  method: ssl
+  base: dc=andrew,dc=cmu,dc=edu
 
 staging:
-  host: ldap.andrew.cmu.edu
-  port: 389
-  base: dc=cmu,dc=edu
+  host: ldap.cmu.edu
+  port: 636
+  method: ssl
+  base: dc=andrew,dc=cmu,dc=edu
 
 production:
-  host: ldap.andrew.cmu.edu
-  port: 389
-  base: dc=cmu,dc=edu
+  host: ldap.cmu.edu
+  port: 636
+  method: ssl
+  base: dc=andrew,dc=cmu,dc=edu


### PR DESCRIPTION
At time of writing, the old service at ldap.andrew.cmu.edu:389 is being decommissioned on or about 2022-02-28.